### PR TITLE
Add confirmation route and log orders

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -3,6 +3,7 @@ import Order from "../models/Order.js";
 import Product from "../models/Product.js";
 import path from "path";
 import fs from "fs";
+import { saveOrderToExcel } from "../services/excelService.js";
 
 // Crea un pedido incluyendo información adicional (checkout)
 export const createOrder = async (req, res) => {
@@ -45,7 +46,7 @@ export const createOrder = async (req, res) => {
       status: "Pendiente",
     });
 
-    // Aquí podrías llamar a un servicio para almacenar la orden en un archivo Excel
+    saveOrderToExcel(order);
 
     return res.status(201).json(order);
   } catch (error) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import RegisterPage from "./pages/RegisterPage";
 import CartPage from "./pages/CartPage";
 import CheckoutForm from "./pages/CheckoutForm"; // si existe
 import ProductDetails from "./pages/ProductDetails"; // si existe
+import ConfirmationPage from "./pages/ConfirmationPage";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Layout from "./components/Layout";
 
@@ -53,6 +54,7 @@ function App() {
               </ProtectedRoute>
             }
           />
+          <Route path="/confirmation" element={<ConfirmationPage />} />
           {/* Agregar otras rutas protegidas según sea necesario */}
         </Routes>
       </Layout>


### PR DESCRIPTION
## Summary
- log orders to Excel on creation
- wire up ConfirmationPage route in React app

## Testing
- `yarn test --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `yarn build`
- `node server.js` *(fails: Error de conexion a MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6879a01d0ec8832db6198766c526f293