### PR TITLE
frontend: reuse ui components across pages

### DIFF
--- a/frontend/src/components/ui/Button.js
+++ b/frontend/src/components/ui/Button.js
@@ -1,9 +1,12 @@
 import React from "react";
 import "./ui.css";
 
-function Button({ variant = "primary", children, ...props }) {
+function Button({ variant = "primary", className = "", children, ...props }) {
   return (
-    <button className={`ui-button ui-button--${variant}`} {...props}>
+    <button
+      className={`ui-button ui-button--${variant} ${className}`}
+      {...props}
+    >
       {children}
     </button>
   );

--- a/frontend/src/components/ui/Card.js
+++ b/frontend/src/components/ui/Card.js
@@ -1,9 +1,9 @@
 import React from "react";
 import "./ui.css";
 
-function Card({ children, ...props }) {
+function Card({ className = "", children, ...props }) {
   return (
-    <div className="ui-card" {...props}>
+    <div className={`ui-card ${className}`} {...props}>
       {children}
     </div>
   );

--- a/frontend/src/components/ui/CardGrid.js
+++ b/frontend/src/components/ui/CardGrid.js
@@ -1,0 +1,12 @@
+import React from "react";
+import "./ui.css";
+
+function CardGrid({ className = "", children, ...props }) {
+  return (
+    <div className={`ui-card-grid ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export default CardGrid;

--- a/frontend/src/components/ui/Form.js
+++ b/frontend/src/components/ui/Form.js
@@ -1,0 +1,12 @@
+import React from "react";
+import "./ui.css";
+
+function Form({ className = "", children, ...props }) {
+  return (
+    <form className={`ui-form ${className}`} {...props}>
+      {children}
+    </form>
+  );
+}
+
+export default Form;

--- a/frontend/src/components/ui/TextInput.js
+++ b/frontend/src/components/ui/TextInput.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "./ui.css";
 
-function TextInput({ label, id, ...props }) {
+function TextInput({ label, id, className = "", ...props }) {
   return (
     <div className="ui-field">
       {label && (
@@ -9,7 +9,7 @@ function TextInput({ label, id, ...props }) {
           {label}
         </label>
       )}
-      <input id={id} className="ui-input" {...props} />
+      <input id={id} className={`ui-input ${className}`} {...props} />
     </div>
   );
 }

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -2,3 +2,5 @@ export { default as Button } from "./Button";
 export { default as Card } from "./Card";
 export { default as Modal } from "./Modal";
 export { default as TextInput } from "./TextInput";
+export { default as Form } from "./Form";
+export { default as CardGrid } from "./CardGrid";

--- a/frontend/src/components/ui/ui.css
+++ b/frontend/src/components/ui/ui.css
@@ -91,6 +91,17 @@
   outline: none;
 }
 
+.ui-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.ui-card-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../css/AdminDashboard.css";
+import { Button } from "../components/ui";
 
 const AdminDashboard = () => {
   const [orders, setOrders] = useState([]);
@@ -44,9 +45,9 @@ const AdminDashboard = () => {
           <p>${summary.totalSales}</p>
         </div>
       </div>
-      <button onClick={handleDownloadExcel} className="download-button">
+      <Button onClick={handleDownloadExcel} className="download-button">
         Descargar Excel de Pedidos
-      </button>
+      </Button>
       <table className="orders-table">
         <thead>
           <tr>

--- a/frontend/src/pages/CartPage.js
+++ b/frontend/src/pages/CartPage.js
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { CartContext } from "../context/CartContext";
 import "../css/CartPage.css";
+import { Button } from "../components/ui";
 
 const CartPage = () => {
   const { cartItems, removeFromCart } = useContext(CartContext);
@@ -33,20 +34,21 @@ const CartPage = () => {
                   <p>Cantidad: {item.quantity}</p>
                   <p>Precio: ${item.product.price}</p>
                 </div>
-                <button
+                <Button
                   className="remove-button"
+                  variant="danger"
                   onClick={() => removeFromCart(item.product._id)}
                 >
                   Eliminar
-                </button>
+                </Button>
               </div>
             ))}
           </div>
           <div className="cart-summary">
             <h2>Total: ${totalPrice}</h2>
-            <button className="checkout-button" onClick={handleCheckout}>
+            <Button className="checkout-button" onClick={handleCheckout}>
               Proceder a Pagar
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/frontend/src/pages/CheckoutForm.js
+++ b/frontend/src/pages/CheckoutForm.js
@@ -2,6 +2,7 @@ import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { CartContext } from "../context/CartContext";
 import "../css/CheckoutForm.css";
+import { Button, Card, Form, TextInput } from "../components/ui";
 
 const CheckoutForm = () => {
   const { cartItems, clearCart } = useContext(CartContext);
@@ -68,7 +69,7 @@ const CheckoutForm = () => {
   return (
     <div className="checkout-form-container">
       <h1>Formulario de Pago</h1>
-      <div className="order-summary">
+      <Card className="order-summary">
         <h2>Resumen del Pedido</h2>
         <ul>
           {cartItems.map((item) => (
@@ -79,31 +80,27 @@ const CheckoutForm = () => {
           ))}
         </ul>
         <h3>Total: ${totalPrice}</h3>
-      </div>
+      </Card>
       {error && <div className="error">{error}</div>}
-      <form onSubmit={handleSubmit} className="checkout-form">
-        <div className="form-group">
-          <label htmlFor="shippingAddress">Dirección de Envío</label>
-          <input
-            type="text"
-            id="shippingAddress"
-            name="shippingAddress"
-            value={formData.shippingAddress}
-            onChange={handleChange}
-            required
-          />
-        </div>
-        <div className="form-group">
-          <label htmlFor="phone">Teléfono</label>
-          <input
-            type="text"
-            id="phone"
-            name="phone"
-            value={formData.phone}
-            onChange={handleChange}
-            required
-          />
-        </div>
+      <Form onSubmit={handleSubmit} className="checkout-form">
+        <TextInput
+          label="Dirección de Envío"
+          id="shippingAddress"
+          name="shippingAddress"
+          type="text"
+          value={formData.shippingAddress}
+          onChange={handleChange}
+          required
+        />
+        <TextInput
+          label="Teléfono"
+          id="phone"
+          name="phone"
+          type="text"
+          value={formData.phone}
+          onChange={handleChange}
+          required
+        />
         <div className="form-group">
           <label htmlFor="instructions">
             Instrucciones Adicionales (opcional)
@@ -115,10 +112,10 @@ const CheckoutForm = () => {
             onChange={handleChange}
           ></textarea>
         </div>
-        <button type="submit" className="submit-button">
+        <Button type="submit" className="submit-button">
           Confirmar Pedido
-        </button>
-      </form>
+        </Button>
+      </Form>
     </div>
   );
 };

--- a/frontend/src/pages/ConfirmationPage.js
+++ b/frontend/src/pages/ConfirmationPage.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import "../css/ConfirmationPage.css";
+import { Button } from "../components/ui";
 
 const ConfirmationPage = () => {
   const location = useLocation();
@@ -30,9 +31,9 @@ const ConfirmationPage = () => {
         </>
       )}
 
-      <button onClick={handleGoHome} className="btn-back-home">
+      <Button onClick={handleGoHome} className="btn-back-home">
         Volver al Inicio
-      </button>
+      </Button>
     </div>
   );
 };

--- a/frontend/src/pages/ContactPage.js
+++ b/frontend/src/pages/ContactPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import "../css/ContactPage.css";
+import { Button, Card, Form, TextInput } from "../components/ui";
 
 const ContactPage = () => {
   const [formData, setFormData] = useState({
@@ -30,34 +31,30 @@ const ContactPage = () => {
         <a href="mailto:info@replasticos.com">info@replasticos.com</a> o llama
         al <a href="tel:+11234567890">(123) 456-7890</a>.
       </p>
-      <div className="contact-form-container">
+      <Card className="contact-form-container">
         <h2>Envíanos un mensaje</h2>
         {success && (
           <p className="success-message">Mensaje enviado con éxito!</p>
         )}
-        <form onSubmit={handleSubmit} className="contact-form">
-          <div className="form-group">
-            <label htmlFor="name">Nombre:</label>
-            <input
-              type="text"
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="email">Correo electrónico:</label>
-            <input
-              type="email"
-              id="email"
-              name="email"
-              value={formData.email}
-              onChange={handleChange}
-              required
-            />
-          </div>
+        <Form onSubmit={handleSubmit} className="contact-form">
+          <TextInput
+            label="Nombre:"
+            id="name"
+            name="name"
+            type="text"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
+          <TextInput
+            label="Correo electrónico:"
+            id="email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+          />
           <div className="form-group">
             <label htmlFor="message">Mensaje:</label>
             <textarea
@@ -69,11 +66,11 @@ const ContactPage = () => {
               required
             ></textarea>
           </div>
-          <button type="submit" className="submit-button">
+          <Button type="submit" className="submit-button">
             Enviar Mensaje
-          </button>
-        </form>
-      </div>
+          </Button>
+        </Form>
+      </Card>
     </div>
   );
 };

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import "../css/HomePage.css";
+import { Button } from "../components/ui";
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -16,9 +17,9 @@ const HomePage = () => {
               verduras, ayudando a productores y empresas a reducir su huella
               ambiental.
             </p>
-            <button className="home-cta" onClick={() => navigate("/products")}>
+            <Button className="home-cta" onClick={() => navigate("/products") }>
               Ver Productos
-            </button>
+            </Button>
           </div>
         </div>
       </section>
@@ -63,9 +64,9 @@ const HomePage = () => {
             <p>Caja apilable</p>
           </div>
         </div>
-        <button className="home-cta" onClick={() => navigate("/products")}>
+        <Button className="home-cta" onClick={() => navigate("/products") }>
           Ver catálogo completo
-        </button>
+        </Button>
       </section>
 
       <section className="impact-section">
@@ -79,9 +80,9 @@ const HomePage = () => {
       <section className="cta-final">
         <h2>Únete al cambio</h2>
         <p>Regístrate ahora y comienza a transformar tu logística.</p>
-        <button className="home-cta" onClick={() => navigate("/register")}>
+        <Button className="home-cta" onClick={() => navigate("/register") }>
           Crear cuenta
-        </button>
+        </Button>
       </section>
     </>
   );

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -4,11 +4,11 @@ import { AuthContext } from "../context/AuthContext";
 import "../css/LoginPage.css";
 
 import Icon from "../icons/Icon";
+import { Button, Card, Form, TextInput } from "../components/ui";
 
 const LoginPage = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
@@ -37,7 +37,7 @@ const LoginPage = () => {
 
   return (
     <div className="login-container">
-      <div className="login-card">
+      <Card className="login-card">
         <div className="login-header">
           <Icon name="leaf" className="login-leaf-icon" />
           <h2>Bienvenido a RePlastiCos</h2>
@@ -48,43 +48,25 @@ const LoginPage = () => {
 
         {error && <div className="error-message">{error}</div>}
 
-        <form onSubmit={handleLogin}>
-          <div className="form-group">
-            <label htmlFor="email">Correo electrónico</label>
-            <div className="input-flex">
-              <Icon name="envelope" className="flex-icon" />
-              <input
-                type="email"
-                id="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="ejemplo@correo.com"
-                required
-              />
-            </div>
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="password">Contraseña</label>
-            <div className="input-flex">
-              <Icon name="lock" className="flex-icon" />
-              <input
-                type={showPassword ? "text" : "password"}
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="Tu contraseña"
-                required
-              />
-              <span
-                className="flex-icon clickable"
-                onClick={() => setShowPassword((prev) => !prev)}
-              >
-                <Icon name={showPassword ? "eyeSlash" : "eye"} />
-              </span>
-            </div>
-          </div>
-
+        <Form onSubmit={handleLogin}>
+          <TextInput
+            label="Correo electrónico"
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="ejemplo@correo.com"
+            required
+          />
+          <TextInput
+            label="Contraseña"
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Tu contraseña"
+            required
+          />
           <div className="form-options">
             <label className="remember-me">
               <input
@@ -98,16 +80,14 @@ const LoginPage = () => {
               ¿Olvidaste tu contraseña?
             </a>
           </div>
-
-          <button type="submit" className="login-button">
+          <Button type="submit" className="login-button">
             Iniciar sesión
-          </button>
-
+          </Button>
           <div className="login-footer">
             ¿No tienes cuenta? <a href="/register">Regístrate</a>
           </div>
-        </form>
-      </div>
+        </Form>
+      </Card>
     </div>
   );
 };

--- a/frontend/src/pages/ManageProducts.js
+++ b/frontend/src/pages/ManageProducts.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import "../css/ManageProducts.css";
 import ProductForm from "../components/ProductForm";
+import { Button, Card, CardGrid } from "../components/ui";
 
 const ManageProducts = () => {
   const [products, setProducts] = useState([]);
@@ -36,9 +37,9 @@ const ManageProducts = () => {
   return (
     <div className="manage-products">
       <h1>Administrar Productos</h1>
-      <div className="products-list">
+      <CardGrid className="products-list">
         {products.map((product) => (
-          <div key={product._id} className="product-card">
+          <Card key={product._id} className="product-card">
             {product.imageUrl ? (
               <img
                 src={product.imageUrl}
@@ -52,14 +53,17 @@ const ManageProducts = () => {
             <p>{product.description}</p>
             <strong>${product.price}</strong>
             <div className="product-actions">
-              <button onClick={() => handleEdit(product._id)}>Editar</button>
-              <button onClick={() => handleDelete(product._id)}>
+              <Button onClick={() => handleEdit(product._id)}>Editar</Button>
+              <Button
+                variant="danger"
+                onClick={() => handleDelete(product._id)}
+              >
                 Eliminar
-              </button>
+              </Button>
             </div>
-          </div>
+          </Card>
         ))}
-      </div>
+      </CardGrid>
       <div className="product-form-section">
         <h2>{editingProductId ? "Editar Producto" : "Agregar Producto"}</h2>
         <ProductForm productId={editingProductId} onSuccess={handleSuccess} />

--- a/frontend/src/pages/ProductDetails.js
+++ b/frontend/src/pages/ProductDetails.js
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { CartContext } from "../context/CartContext";
 import "../css/ProductDetails.css";
 import Icon from "../icons/Icon";
+import { Button, TextInput } from "../components/ui";
 
 const ProductDetails = () => {
   const { id } = useParams();
@@ -42,16 +43,16 @@ const ProductDetails = () => {
       <p className="product-description">{product.description}</p>
       <p className="product-price">Precio: ${product.price}</p>
       <div className="purchase-info">
-        <label htmlFor="quantity">Cantidad (mínimo 50): </label>
-        <input
-          type="number"
+        <TextInput
+          label="Cantidad (mínimo 50):"
           id="quantity"
+          type="number"
           value={quantity}
-          min="50"
+          min={50}
           onChange={(e) => setQuantity(Number(e.target.value))}
         />
         {error && <p className="error">{error}</p>}
-        <button onClick={handleAddToCart}>Añadir al carrito</button>
+        <Button onClick={handleAddToCart}>Añadir al carrito</Button>
       </div>
       <div className="additional-info">
         <p>

--- a/frontend/src/pages/ProductsPage.js
+++ b/frontend/src/pages/ProductsPage.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { CartContext } from "../context/CartContext";
 import "../css/ProductsPage.css";
+import { Button, Card, CardGrid } from "../components/ui";
 
 const ProductsPage = () => {
   const [products, setProducts] = useState([]);
@@ -20,9 +21,9 @@ const ProductsPage = () => {
       <div className="products-container">
         <h1>Productos</h1>
         {products.length > 0 ? (
-          <div className="products-grid">
+          <CardGrid className="products-grid">
             {products.map((product) => (
-              <div key={product._id} className="product-card">
+              <Card key={product._id} className="product-card">
                 <Link to={`/product/${product._id}`}>
                   {product.imageUrl ? (
                     <img
@@ -37,12 +38,12 @@ const ProductsPage = () => {
                 </Link>
                 <p>{product.description.substring(0, 50)}...</p>
                 <strong>${product.price}</strong>
-                <button onClick={() => addToCart(product)}>
+                <Button onClick={() => addToCart(product)}>
                   Añadir al carrito
-                </button>
-              </div>
+                </Button>
+              </Card>
             ))}
-          </div>
+          </CardGrid>
         ) : (
           <p className="no-products">No hay productos disponibles.</p>
         )}

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../css/RegisterPage.css";
+import { Button, Card, Form, TextInput } from "../components/ui";
 
 const RegisterPage = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
 
@@ -36,57 +36,44 @@ const RegisterPage = () => {
         <h1>Replasticos</h1>
         <p>Regístrate para gestionar tus pedidos de contenedores plásticos.</p>
       </div>
-      <div className="register-card">
+      <Card className="register-card">
         <h2>Crea tu cuenta</h2>
         {error && <div className="error-message">{error}</div>}
-        <form onSubmit={handleRegister} className="form">
-          <div className="form-group">
-            <label htmlFor="name">Nombre</label>
-            <input
-              type="text"
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Tu nombre completo"
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="email">Correo electrónico</label>
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="empresa@correo.com"
-              required
-            />
-          </div>
-          <div className="form-group password-group">
-            <label htmlFor="password">Contraseña</label>
-            <input
-              type={showPassword ? "text" : "password"}
-              id="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Mínimo 8 caracteres"
-              required
-            />
-            <span
-              className="toggle-password"
-              onClick={() => setShowPassword((prev) => !prev)}
-            >
-              {showPassword ? "Ocultar" : "Mostrar"}
-            </span>
-          </div>
-          <button type="submit" className="register-button">
+        <Form onSubmit={handleRegister} className="form">
+          <TextInput
+            label="Nombre"
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Tu nombre completo"
+            required
+          />
+          <TextInput
+            label="Correo electrónico"
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="empresa@correo.com"
+            required
+          />
+          <TextInput
+            label="Contraseña"
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Mínimo 8 caracteres"
+            required
+          />
+          <Button type="submit" className="register-button">
             Registrarme
-          </button>
-        </form>
+          </Button>
+        </Form>
         <div className="login-link">
           ¿Ya tienes cuenta? <a href="/login">Inicia sesión</a>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend Button, Card, and TextInput with className support
- add Form and CardGrid components and export through UI index
- refactor pages to use shared UI components

## Testing
- `cd backend && yarn install`
- `cd ../frontend && yarn install`
- `yarn test --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_6892603ce6ac832d96823a00fb9e9a7f