### PR TITLE
frontend: add accessible focus outlines

### DIFF
--- a/frontend/src/components/AdminNavbar.js
+++ b/frontend/src/components/AdminNavbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import "../css/Navbar.css";
 
@@ -11,6 +11,16 @@ const AdminNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <header className="navbar">
       <div className="navbar-container">
@@ -20,12 +30,18 @@ const AdminNavbar = ({ onLogout }) => {
         </Link>
         <button
           className="navbar-toggle"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          aria-expanded={menuOpen}
           onClick={() => setMenuOpen(!menuOpen)}
         >
           &#9776;
         </button>
         <nav className="navbar-menu">
-          <ul className={`navbar-links ${menuOpen ? "open" : ""}`}>
+          <ul
+            id="primary-navigation"
+            className={`navbar-links ${menuOpen ? "open" : ""}`}
+          >
             <li>
               <NavLink to="/manage-products">Administrar Productos</NavLink>
             </li>

--- a/frontend/src/components/GuestNavbar.js
+++ b/frontend/src/components/GuestNavbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { Link, NavLink } from "react-router-dom";
 import "../css/Navbar.css";
 import { CartContext } from "../context/CartContext";
@@ -7,6 +7,16 @@ const GuestNavbar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { cartItems } = useContext(CartContext);
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <header className="navbar">
       <div className="navbar-container">
@@ -14,11 +24,20 @@ const GuestNavbar = () => {
           <img src="/logo.svg" alt="RePlastiCos" className="logo" />
           <span className="brand-text"></span>
         </Link>
-        <button className="navbar-toggle" onClick={() => setMenuOpen(!menuOpen)}>
+        <button
+          className="navbar-toggle"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
           &#9776;
         </button>
         <nav className="navbar-menu">
-          <ul className={`navbar-links ${menuOpen ? "open" : ""}`}>
+          <ul
+            id="primary-navigation"
+            className={`navbar-links ${menuOpen ? "open" : ""}`}
+          >
             <li>
               <NavLink to="/" end>
                 Inicio

--- a/frontend/src/components/UserNavbar.js
+++ b/frontend/src/components/UserNavbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import "../css/Navbar.css";
 import { CartContext } from "../context/CartContext";
@@ -13,6 +13,16 @@ const UserNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <header className="navbar">
       <div className="navbar-container">
@@ -20,11 +30,20 @@ const UserNavbar = ({ onLogout }) => {
           <img src="/logo.svg" alt="RePlastiCos" className="logo" />
           <span className="brand-text"></span>
         </Link>
-        <button className="navbar-toggle" onClick={() => setMenuOpen(!menuOpen)}>
+        <button
+          className="navbar-toggle"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
           &#9776;
         </button>
         <nav className="navbar-menu">
-          <ul className={`navbar-links ${menuOpen ? "open" : ""}`}>
+          <ul
+            id="primary-navigation"
+            className={`navbar-links ${menuOpen ? "open" : ""}`}
+          >
             <li>
               <NavLink to="/" end>
                 Inicio

--- a/frontend/src/components/ui/Modal.js
+++ b/frontend/src/components/ui/Modal.js
@@ -1,8 +1,26 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import "./ui.css";
 import motion from "../../design/motion";
 
 function Modal({ isOpen, onClose, children }) {
+  const closeRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    if (closeRef.current) {
+      closeRef.current.focus();
+    }
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) {
     return null;
   }
@@ -14,7 +32,12 @@ function Modal({ isOpen, onClose, children }) {
       aria-modal="true"
     >
       <div className="ui-modal" style={motion.scale({ overlay: true })}>
-        <button className="ui-modal-close" onClick={onClose} aria-label="Close">
+        <button
+          ref={closeRef}
+          className="ui-modal-close"
+          onClick={onClose}
+          aria-label="Close"
+        >
           ×
         </button>
         {children}

--- a/frontend/src/components/ui/ui.css
+++ b/frontend/src/components/ui/ui.css
@@ -31,8 +31,8 @@
 .ui-button--danger:hover {
   background-color: var(--color-danger-dark);
 }
-.ui-button:focus {
-  outline: 2px solid var(--color-secondary);
+.ui-button:focus-visible {
+  outline: 3px solid var(--color-focus-outline);
   outline-offset: 2px;
 }
 .ui-button:hover {
@@ -89,9 +89,10 @@
   border: 1px solid var(--color-border);
   border-radius: 4px;
 }
-.ui-input:focus {
+.ui-input:focus-visible {
   border-color: var(--color-secondary);
-  outline: none;
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .ui-form {

--- a/frontend/src/css/CheckoutForm.css
+++ b/frontend/src/css/CheckoutForm.css
@@ -57,10 +57,11 @@
   font-size: var(--font-size-md);
 }
 
-.checkout-form input:focus,
-.checkout-form textarea:focus {
+.checkout-form input:focus-visible,
+.checkout-form textarea:focus-visible {
   border-color: var(--color-secondary);
-  outline: none;
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .submit-button {

--- a/frontend/src/css/ContactPage.css
+++ b/frontend/src/css/ContactPage.css
@@ -63,10 +63,11 @@
   border-radius: 4px;
 }
 
-.contact-form input:focus,
-.contact-form textarea:focus {
-  outline: none;
+.contact-form input:focus-visible,
+.contact-form textarea:focus-visible {
   border-color: var(--color-secondary);
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .submit-button {

--- a/frontend/src/css/LoginPage.css
+++ b/frontend/src/css/LoginPage.css
@@ -75,8 +75,12 @@ body {
   padding: 0;
   font-size: var(--font-size-md);
   background: transparent;
-  outline: none;
   color: var(--color-text);
+}
+
+.input-flex input:focus-visible {
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .flex-icon {

--- a/frontend/src/css/Navbar.css
+++ b/frontend/src/css/Navbar.css
@@ -52,6 +52,11 @@
   transition: color 0.2s ease;
 }
 
+.navbar-links li a:focus-visible {
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
+}
+
 .navbar-links li a:hover,
 .navbar-links li a.active {
   color: var(--color-background-lighter);
@@ -75,6 +80,11 @@
   border: none;
   font-size: var(--font-size-xl);
   cursor: pointer;
+}
+
+.navbar-toggle:focus-visible {
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/css/ProductDetails.css
+++ b/frontend/src/css/ProductDetails.css
@@ -78,12 +78,13 @@
   background-color: var(--color-gray-300);
   font-size: var(--font-size-md);
   box-shadow: inset 0 0 0 1px var(--color-gray-700);
-  outline: none;
   transition: box-shadow 0.2s ease;
 }
 
-.purchase-info input:focus {
+.purchase-info input:focus-visible {
   box-shadow: 0 0 0 2px var(--color-success)44;
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .purchase-info button {

--- a/frontend/src/css/ProductForm.css
+++ b/frontend/src/css/ProductForm.css
@@ -34,10 +34,11 @@
   font-size: var(--font-size-md);
 }
 
-.form-group input:focus,
-.form-group textarea:focus {
-  outline: none;
+.form-group input:focus-visible,
+.form-group textarea:focus-visible {
   border-color: var(--color-secondary);
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .submit-button {

--- a/frontend/src/css/RegisterPage.css
+++ b/frontend/src/css/RegisterPage.css
@@ -64,12 +64,13 @@ body {
   border-radius: 8px;
   font-size: var(--font-size-md);
   background-color: var(--color-gray-300);
-  outline: none;
   transition: box-shadow 0.2s ease;
 }
 
-.form-group input:focus {
+.form-group input:focus-visible {
   box-shadow: 0 0 0 2px var(--color-success)44;
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
 }
 
 .password-group {

--- a/frontend/src/design/tokens.css
+++ b/frontend/src/design/tokens.css
@@ -28,6 +28,7 @@
   --color-gray-700: #cccccc;
   --color-gray-800: #eeeeee;
   --color-overlay-dark: rgba(0, 0, 0, 0.55);
+  --color-focus-outline: #000000;
   --color-success: #4caf50;
   --color-success-dark: #388e3c;
   --color-success-alpha: #4caf5044;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,3 +12,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--color-focus-outline);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add high contrast focus token and global focus-visible styles
- label and manage keyboard for nav menus and modal

## Testing
- `node server.js` *(fails: Error de conexión a MongoDB)*
- `yarn test --watchAll=false`
- `yarn build`
- `node -e "const axe=require('./frontend/node_modules/axe-core');const c1=new axe.commons.color.Color();c1.parseHexString('#000000');const c2=new axe.commons.color.Color();c2.parseHexString('#f2f2f2');const contrast=axe.commons.color.hasValidContrastRatio(c1,c2);console.log(contrast);"`

------
https://chatgpt.com/codex/tasks/task_e_68926bcb6ffc832da6fbf1db047bf53a