### PR TITLE
frontend: unify navbars and add tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import Navbar from "./components/Navbar";
+import Navbar from "./components/RoleNavbar";
 import HomePage from "./pages/HomePage";
 import AboutPage from "./pages/AboutPage";
 import ProductsPage from "./pages/ProductsPage";

--- a/frontend/src/components/AdminNavbar.js
+++ b/frontend/src/components/AdminNavbar.js
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from "react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
-import "../css/Navbar.css";
+import React from "react";
+import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
+import Navbar from "./Navbar";
 
 const AdminNavbar = ({ onLogout }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -11,53 +11,16 @@ const AdminNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  const menuItems = [
+    { to: "/manage-products", label: "Administrar Productos" },
+    { to: "/admin", label: "Dashboard" },
+  ];
 
-  return (
-    <header className="navbar">
-      <div className="navbar-container">
-        <Link className="navbar-brand" to="/">
-          <img src="/logo.svg" alt="RePlastiCos" className="logo" />
-          <span className="brand-text"></span>
-        </Link>
-        <button
-          className="navbar-toggle"
-          aria-label="Toggle navigation"
-          aria-controls="primary-navigation"
-          aria-expanded={menuOpen}
-          onClick={() => setMenuOpen(!menuOpen)}
-        >
-          &#9776;
-        </button>
-        <nav className="navbar-menu">
-          <ul
-            id="primary-navigation"
-            className={`navbar-links ${menuOpen ? "open" : ""}`}
-          >
-            <li>
-              <NavLink to="/manage-products">Administrar Productos</NavLink>
-            </li>
-            <li>
-              <NavLink to="/admin">Dashboard</NavLink>
-            </li>
-            <li>
-              <button onClick={handleLogout} className="logout-button">
-                Logout
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </header>
-  );
+  return <Navbar menuItems={menuItems} onLogout={handleLogout} />;
+};
+
+AdminNavbar.propTypes = {
+  onLogout: PropTypes.func.isRequired,
 };
 
 export default AdminNavbar;

--- a/frontend/src/components/GuestNavbar.js
+++ b/frontend/src/components/GuestNavbar.js
@@ -1,78 +1,29 @@
-import React, { useState, useContext, useEffect } from "react";
-import { Link, NavLink } from "react-router-dom";
-import "../css/Navbar.css";
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import Navbar from "./Navbar";
 import { CartContext } from "../context/CartContext";
 
 const GuestNavbar = () => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const { cartItems } = useContext(CartContext);
 
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  const menuItems = [
+    { to: "/", label: "Inicio", end: true },
+    { to: "/about", label: "Nosotros" },
+    { to: "/products", label: "Tienda" },
+    { to: "/contact", label: "Contacto" },
+    { to: "/login", label: "Login" },
+    { to: "/register", label: "Registro" },
+  ];
 
   return (
-    <header className="navbar">
-      <div className="navbar-container">
-        <Link className="navbar-brand" to="/">
-          <img src="/logo.svg" alt="RePlastiCos" className="logo" />
-          <span className="brand-text"></span>
-        </Link>
-        <button
-          className="navbar-toggle"
-          aria-label="Toggle navigation"
-          aria-controls="primary-navigation"
-          aria-expanded={menuOpen}
-          onClick={() => setMenuOpen(!menuOpen)}
-        >
-          &#9776;
-        </button>
-        <nav className="navbar-menu">
-          <ul
-            id="primary-navigation"
-            className={`navbar-links ${menuOpen ? "open" : ""}`}
-          >
-            <li>
-              <NavLink to="/" end>
-                Inicio
-              </NavLink>
-            </li>
-            <li>
-              <NavLink to="/about">Nosotros</NavLink>
-            </li>
-            <li>
-              <NavLink to="/products">Tienda</NavLink>
-            </li>
-            <li>
-              <NavLink to="/cart">
-                <span className="cart-link-content">
-                  Carrito
-                  {cartItems.length > 0 && (
-                    <span className="cart-badge">{cartItems.length}</span>
-                  )}
-                </span>
-              </NavLink>
-            </li>
-            <li>
-              <NavLink to="/contact">Contacto</NavLink>
-            </li>
-            <li>
-              <NavLink to="/login">Login</NavLink>
-            </li>
-            <li>
-              <NavLink to="/register">Registro</NavLink>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </header>
+    <Navbar
+      menuItems={menuItems}
+      showCart
+      cartCount={cartItems.length}
+    />
   );
 };
+
+GuestNavbar.propTypes = {};
 
 export default GuestNavbar;

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,21 +1,100 @@
-import React, { useContext } from "react";
-import { AuthContext } from "../context/AuthContext";
-import GuestNavbar from "./GuestNavbar";
-import UserNavbar from "./UserNavbar";
-import AdminNavbar from "./AdminNavbar";
+import React, { useState, useEffect, useId } from "react";
+import PropTypes from "prop-types";
+import { Link, NavLink } from "react-router-dom";
+import "../css/Navbar.css";
+import { Bars3Icon } from "@heroicons/react/24/solid";
 
-const Navbar = () => {
-  const { userInfo, logout } = useContext(AuthContext);
+const Navbar = ({ menuItems, showCart = false, cartCount = 0, onLogout }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuId = useId();
 
-  if (!userInfo) {
-    return <GuestNavbar />;
-  }
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
-  if (userInfo.role === "admin") {
-    return <AdminNavbar onLogout={logout} />;
-  }
+  const handleLinkClick = () => setMenuOpen(false);
 
-  return <UserNavbar onLogout={logout} />;
+  const handleLogout = () => {
+    if (onLogout) {
+      onLogout();
+    }
+    handleLinkClick();
+  };
+
+  return (
+    <header className="navbar">
+      <div className="navbar-container">
+        <Link className="navbar-brand" to="/" onClick={handleLinkClick}>
+          <img src="/logo.svg" alt="RePlastiCos" className="logo" />
+          <span className="brand-text"></span>
+        </Link>
+        <button
+          className="navbar-toggle"
+          aria-label="Toggle navigation"
+          aria-controls={menuId}
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          <span aria-hidden="true">
+            <Bars3Icon width={24} height={24} />
+          </span>
+        </button>
+        <nav className="navbar-menu">
+          <ul id={menuId} className={`navbar-links ${menuOpen ? "open" : ""}`}>
+            {menuItems.map((item) => (
+              <li key={item.to}>
+                <NavLink
+                  to={item.to}
+                  end={item.end}
+                  onClick={handleLinkClick}
+                >
+                  {item.label}
+                </NavLink>
+              </li>
+            ))}
+            {showCart && (
+              <li>
+                <NavLink to="/cart" onClick={handleLinkClick}>
+                  <span className="cart-link-content">
+                    Carrito
+                    {cartCount > 0 && (
+                      <span className="cart-badge">{cartCount}</span>
+                    )}
+                  </span>
+                </NavLink>
+              </li>
+            )}
+            {onLogout && (
+              <li>
+                <button onClick={handleLogout} className="logout-button">
+                  Logout
+                </button>
+              </li>
+            )}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+Navbar.propTypes = {
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      to: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      end: PropTypes.bool,
+    })
+  ).isRequired,
+  showCart: PropTypes.bool,
+  cartCount: PropTypes.number,
+  onLogout: PropTypes.func,
 };
 
 export default Navbar;

--- a/frontend/src/components/RoleNavbar.js
+++ b/frontend/src/components/RoleNavbar.js
@@ -1,0 +1,24 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import { AuthContext } from "../context/AuthContext";
+import GuestNavbar from "./GuestNavbar";
+import UserNavbar from "./UserNavbar";
+import AdminNavbar from "./AdminNavbar";
+
+const Navbar = () => {
+  const { userInfo, logout } = useContext(AuthContext);
+
+  if (!userInfo) {
+    return <GuestNavbar />;
+  }
+
+  if (userInfo.role === "admin") {
+    return <AdminNavbar onLogout={logout} />;
+  }
+
+  return <UserNavbar onLogout={logout} />;
+};
+
+Navbar.propTypes = {};
+
+export default Navbar;

--- a/frontend/src/components/UserNavbar.js
+++ b/frontend/src/components/UserNavbar.js
@@ -1,10 +1,10 @@
-import React, { useState, useContext, useEffect } from "react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
-import "../css/Navbar.css";
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
+import Navbar from "./Navbar";
 import { CartContext } from "../context/CartContext";
 
 const UserNavbar = ({ onLogout }) => {
-  const [menuOpen, setMenuOpen] = useState(false);
   const { cartItems } = useContext(CartContext);
   const navigate = useNavigate();
 
@@ -13,71 +13,25 @@ const UserNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  const menuItems = [
+    { to: "/", label: "Inicio", end: true },
+    { to: "/about", label: "Nosotros" },
+    { to: "/products", label: "Tienda" },
+    { to: "/contact", label: "Contacto" },
+  ];
 
   return (
-    <header className="navbar">
-      <div className="navbar-container">
-        <Link className="navbar-brand" to="/">
-          <img src="/logo.svg" alt="RePlastiCos" className="logo" />
-          <span className="brand-text"></span>
-        </Link>
-        <button
-          className="navbar-toggle"
-          aria-label="Toggle navigation"
-          aria-controls="primary-navigation"
-          aria-expanded={menuOpen}
-          onClick={() => setMenuOpen(!menuOpen)}
-        >
-          &#9776;
-        </button>
-        <nav className="navbar-menu">
-          <ul
-            id="primary-navigation"
-            className={`navbar-links ${menuOpen ? "open" : ""}`}
-          >
-            <li>
-              <NavLink to="/" end>
-                Inicio
-              </NavLink>
-            </li>
-            <li>
-              <NavLink to="/about">Nosotros</NavLink>
-            </li>
-            <li>
-              <NavLink to="/products">Tienda</NavLink>
-            </li>
-            <li>
-              <NavLink to="/cart">
-                <span className="cart-link-content">
-                  Carrito
-                  {cartItems.length > 0 && (
-                    <span className="cart-badge">{cartItems.length}</span>
-                  )}
-                </span>
-              </NavLink>
-            </li>
-            <li>
-              <NavLink to="/contact">Contacto</NavLink>
-            </li>
-            <li>
-              <button onClick={handleLogout} className="logout-button">
-                Logout
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </header>
+    <Navbar
+      menuItems={menuItems}
+      showCart
+      cartCount={cartItems.length}
+      onLogout={handleLogout}
+    />
   );
+};
+
+UserNavbar.propTypes = {
+  onLogout: PropTypes.func.isRequired,
 };
 
 export default UserNavbar;

--- a/frontend/src/components/__tests__/Navbar.test.js
+++ b/frontend/src/components/__tests__/Navbar.test.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+jest.mock(
+  "react-router-dom",
+  () => ({
+    Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+    NavLink: ({ children, end, ...props }) => <a {...props}>{children}</a>,
+    useNavigate: () => jest.fn(),
+  }),
+  { virtual: true }
+);
+import GuestNavbar from "../GuestNavbar";
+import UserNavbar from "../UserNavbar";
+import AdminNavbar from "../AdminNavbar";
+import { CartContext } from "../../context/CartContext";
+
+describe("Navbar", () => {
+  const renderWithProviders = (ui, { cartItems = [] } = {}) => {
+    return render(
+      <CartContext.Provider value={{ cartItems }}>{ui}</CartContext.Provider>
+    );
+  };
+
+  test("toggles menu visibility", () => {
+    renderWithProviders(<GuestNavbar />);
+    const toggle = screen.getByLabelText(/toggle navigation/i);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("renders role-specific links", () => {
+    renderWithProviders(<GuestNavbar />);
+    expect(screen.getByText("Login")).toBeInTheDocument();
+    renderWithProviders(<AdminNavbar onLogout={() => {}} />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+
+  test("updates cart badge", () => {
+    renderWithProviders(<UserNavbar onLogout={() => {}} />, {
+      cartItems: [{}, {}],
+    });
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  test("closes menu after link click", () => {
+    renderWithProviders(<GuestNavbar />);
+    const toggle = screen.getByLabelText(/toggle navigation/i);
+    fireEvent.click(toggle);
+    const link = screen.getByText("Nosotros");
+    fireEvent.click(link);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## Summary
- create shared navbar with toggle icon, cart badge and logout handling
- wrap role-specific navbars around shared component
- test menu toggle, role links, cart badge and menu close

## Testing
- `cd backend && yarn install`
- `cd ../frontend && yarn install`
- `yarn test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689273e4a6b4832da70cac07444700b3