### PR TITLE
frontend: enhance navbar accessibility

### DIFF
--- a/frontend/src/css/Navbar.css
+++ b/frontend/src/css/Navbar.css
@@ -149,3 +149,15 @@
 .logout-button:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- close navbar when clicking outside
- trap focus and manage focus for mobile menu
- announce cart item count with ARIA label and live region

## Testing
- `cd backend && yarn install`
- `node server.js` *(fails: Error de conexión a MongoDB: ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6892764e5a2c832db1dd1cd7e79dd289