### PR TITLE
Add order pagination and filters

### DIFF
--- a/frontend/src/css/AdminDashboard.css
+++ b/frontend/src/css/AdminDashboard.css
@@ -45,6 +45,29 @@
   background-color: var(--color-primary-dark);
 }
 
+.controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.filters {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.filters input,
+.filters select {
+  padding: var(--space-2);
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .orders-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add pagination, limit, status and date range filters to order API
- request paginated orders with filtering in admin dashboard and add controls
- style admin dashboard filters and pagination controls

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `cd frontend && yarn test --watchAll=false`
- `cd frontend && yarn build`
- `cd backend && node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68927ad5f98c832d812321e96ca42a19