### PR TITLE
frontend: guard against undefined orders in admin dashboard

### DIFF
--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -35,8 +35,8 @@ const AdminDashboard = () => {
     })
       .then((res) => res.json())
       .then((data) => {
-        setOrders(data.orders);
-        setTotalPages(data.totalPages);
+        setOrders(Array.isArray(data.orders) ? data.orders : []);
+        setTotalPages(data.totalPages || 1);
       })
       .catch((err) => console.error("Error fetching orders:", err));
   };


### PR DESCRIPTION
## Summary
- ensure orders is always an array before mapping
- default totalPages when backend omits the field

## Testing
- `node server.js` *(fails: querySrv ENOTFOUND)*
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68927d9198f0832d98735f43722c924c