### PR TITLE
backend, frontend: Add order status update

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -105,6 +105,24 @@ export const getOrders = async (req, res) => {
   }
 };
 
+// Actualiza el estado de un pedido
+export const updateOrderStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body;
+    const order = await Order.findByIdAndUpdate(id, { status }, { new: true });
+    if (!order) {
+      return res.status(404).json({ message: "Pedido no encontrado" });
+    }
+    return res.json(order);
+  } catch (error) {
+    return res.status(500).json({
+      message: "Error al actualizar el estado del pedido",
+      error: error.message,
+    });
+  }
+};
+
 // Función para descargar el archivo Excel de pedidos
 export const downloadOrdersExcel = (req, res) => {
   const filePath = path.join(process.cwd(), "data", "pedidos.xlsx");

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -1,7 +1,11 @@
 // backend/routes/orderRoutes.js
 import express from "express";
-import { createOrder, getOrders } from "../controllers/orderController.js";
-import { downloadOrdersExcel } from "../controllers/orderController.js";
+import {
+  createOrder,
+  getOrders,
+  updateOrderStatus,
+  downloadOrdersExcel,
+} from "../controllers/orderController.js";
 
 const router = express.Router();
 
@@ -9,6 +13,8 @@ const router = express.Router();
 router.post("/", createOrder);
 // Ruta para obtener pedidos (puedes protegerla según la autenticación)
 router.get("/", getOrders);
+
+router.patch("/:id/status", updateOrderStatus);
 
 router.get("/download", downloadOrdersExcel);
 

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -56,6 +56,31 @@ const AdminDashboard = () => {
     window.open("http://localhost:5000/api/orders/download", "_blank");
   };
 
+  const handleStatusChange = (id, newStatus) => {
+    const previous = [...orders];
+    setOrders((curr) =>
+      curr.map((o) => (o._id === id ? { ...o, status: newStatus } : o))
+    );
+    fetch(`http://localhost:5000/api/orders/${id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: newStatus }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("Error actualizando el estado");
+        }
+        return res.json();
+      })
+      .catch((err) => {
+        console.error("Error updating status:", err);
+        setOrders(previous);
+      });
+  };
+
   return (
     <div className="admin-dashboard grid cols-1">
       <h1>Dashboard de Administrador</h1>
@@ -143,7 +168,17 @@ const AdminDashboard = () => {
               <td>{order._id}</td>
               <td>{order.user || "N/A"}</td>
               <td>${order.totalPrice}</td>
-              <td>{order.status}</td>
+              <td>
+                <select
+                  value={order.status}
+                  onChange={(e) =>
+                    handleStatusChange(order._id, e.target.value)
+                  }
+                >
+                  <option value="Pendiente">Pendiente</option>
+                  <option value="Completado">Completado</option>
+                </select>
+              </td>
               <td>{order.shippingAddress}</td>
               <td>{order.phone}</td>
               <td>{order.instructions}</td>


### PR DESCRIPTION
## Summary
- allow admins to update order status via new PATCH endpoint
- enable status changes from admin dashboard with optimistic UI

## Testing
- `node server.js` *(fails: Error de conexión a MongoDB: ENOTFOUND)*
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6892810da068832db771b84100bf93e6