### PR TITLE
frontend: enhance admin dashboard filtering and sorting

### DIFF
--- a/frontend/src/css/AdminDashboard.css
+++ b/frontend/src/css/AdminDashboard.css
@@ -84,3 +84,49 @@
   background-color: var(--color-gray-200);
   color: var(--color-text);
 }
+
+.orders-table th.sortable {
+  cursor: pointer;
+}
+
+.orders-table th.sortable.asc::after {
+  content: " \25B2";
+}
+
+.orders-table th.sortable.desc::after {
+  content: " \25BC";
+}
+
+.spinner {
+  text-align: center;
+  margin: var(--space-4) 0;
+}
+
+.error-message {
+  color: red;
+  text-align: center;
+  margin: var(--space-4) 0;
+}
+
+@media (max-width: 768px) {
+  .summary-cards {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-4);
+  }
+
+  .pagination {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .orders-table {
+    display: block;
+    overflow-x: auto;
+  }
+}

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -1,5 +1,5 @@
 // src/pages/AdminDashboard.js
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import "../css/AdminDashboard.css";
 import { Button } from "../components/ui";
@@ -12,14 +12,22 @@ const AdminDashboard = () => {
   const [statusFilter, setStatusFilter] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const limit = 10;
+  const [searchTerm, setSearchTerm] = useState("");
+  const [pageSize, setPageSize] = useState(10);
+  const [sortConfig, setSortConfig] = useState({ key: "", direction: "asc" });
+  const [loadingOrders, setLoadingOrders] = useState(false);
+  const [ordersError, setOrdersError] = useState("");
+  const [loadingSummary, setLoadingSummary] = useState(false);
+  const [summaryError, setSummaryError] = useState("");
   const navigate = useNavigate();
   const token = localStorage.getItem("token");
 
   const getOrders = () => {
+    setLoadingOrders(true);
+    setOrdersError("");
     const params = new URLSearchParams({
       page: currentPage,
-      limit,
+      limit: pageSize,
     });
     if (statusFilter) {
       params.append("status", statusFilter);
@@ -30,26 +38,49 @@ const AdminDashboard = () => {
     if (endDate) {
       params.append("endDate", endDate);
     }
+    if (searchTerm) {
+      params.append("search", searchTerm);
+    }
     fetch(`http://localhost:5000/api/orders?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())
       .then((data) => {
-        setOrders(Array.isArray(data.orders) ? data.orders : []);
+        let fetched = Array.isArray(data.orders) ? data.orders : [];
+        if (searchTerm) {
+          const lowered = searchTerm.toLowerCase();
+          fetched = fetched.filter(
+            (o) =>
+              o._id.toLowerCase().includes(lowered) ||
+              (o.user && o.user.toLowerCase().includes(lowered))
+          );
+        }
+        setOrders(fetched);
         setTotalPages(data.totalPages || 1);
       })
-      .catch((err) => console.error("Error fetching orders:", err));
+      .catch(() => setOrdersError("Error fetching orders"))
+      .finally(() => setLoadingOrders(false));
   };
 
   useEffect(() => {
     getOrders();
-  }, [token, currentPage, statusFilter, startDate, endDate]);
+  }, [
+    token,
+    currentPage,
+    statusFilter,
+    startDate,
+    endDate,
+    pageSize,
+    searchTerm,
+  ]);
 
   useEffect(() => {
+    setLoadingSummary(true);
     fetch("http://localhost:5000/api/admin/summary")
       .then((res) => res.json())
       .then((data) => setSummary(data))
-      .catch((err) => console.error("Error fetching summary:", err));
+      .catch(() => setSummaryError("Error fetching summary"))
+      .finally(() => setLoadingSummary(false));
   }, []);
 
   const handleDownloadExcel = () => {
@@ -81,23 +112,64 @@ const AdminDashboard = () => {
       });
   };
 
+  const handleSort = (key) => {
+    setSortConfig((prev) => {
+      const direction =
+        prev.key === key && prev.direction === "asc" ? "desc" : "asc";
+      return { key, direction };
+    });
+  };
+
+  const sortedOrders = useMemo(() => {
+    const sortable = [...orders];
+    if (sortConfig.key) {
+      sortable.sort((a, b) => {
+        let aVal = a[sortConfig.key];
+        let bVal = b[sortConfig.key];
+        if (sortConfig.key === "createdAt") {
+          aVal = new Date(aVal).getTime();
+          bVal = new Date(bVal).getTime();
+        } else if (typeof aVal === "number" && typeof bVal === "number") {
+          // keep as numbers
+        } else {
+          aVal = aVal ? aVal.toString().toLowerCase() : "";
+          bVal = bVal ? bVal.toString().toLowerCase() : "";
+        }
+        if (aVal < bVal) {
+          return sortConfig.direction === "asc" ? -1 : 1;
+        }
+        if (aVal > bVal) {
+          return sortConfig.direction === "asc" ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+    return sortable;
+  }, [orders, sortConfig]);
+
   return (
     <div className="admin-dashboard grid cols-1">
       <h1>Dashboard de Administrador</h1>
-      <div className="summary-cards">
-        <div className="summary-card">
-          <h3>Usuarios</h3>
-          <p>{summary.users}</p>
+      {loadingSummary ? (
+        <div className="spinner">Cargando resumen...</div>
+      ) : summaryError ? (
+        <div className="error-message">{summaryError}</div>
+      ) : (
+        <div className="summary-cards">
+          <div className="summary-card">
+            <h3>Usuarios</h3>
+            <p>{summary.users}</p>
+          </div>
+          <div className="summary-card">
+            <h3>Pedidos</h3>
+            <p>{summary.orders}</p>
+          </div>
+          <div className="summary-card">
+            <h3>Ventas</h3>
+            <p>${summary.totalSales}</p>
+          </div>
         </div>
-        <div className="summary-card">
-          <h3>Pedidos</h3>
-          <p>{summary.orders}</p>
-        </div>
-        <div className="summary-card">
-          <h3>Ventas</h3>
-          <p>${summary.totalSales}</p>
-        </div>
-      </div>
+      )}
       <Button onClick={handleDownloadExcel} className="download-button">
         Descargar Excel de Pedidos
       </Button>
@@ -119,6 +191,15 @@ const AdminDashboard = () => {
               setCurrentPage(1);
             }}
           />
+          <input
+            type="text"
+            placeholder="Buscar por usuario o ID"
+            value={searchTerm}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+              setCurrentPage(1);
+            }}
+          />
           <select
             value={statusFilter}
             onChange={(e) => {
@@ -132,6 +213,17 @@ const AdminDashboard = () => {
           </select>
         </div>
         <div className="pagination">
+          <select
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value));
+              setCurrentPage(1);
+            }}
+          >
+            <option value={5}>5</option>
+            <option value={10}>10</option>
+            <option value={20}>20</option>
+          </select>
           <Button
             onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
             disabled={currentPage === 1}
@@ -149,44 +241,85 @@ const AdminDashboard = () => {
           </Button>
         </div>
       </div>
-      <table className="orders-table">
-        <thead>
-          <tr>
-            <th>ID Orden</th>
-            <th>Usuario</th>
-            <th>Total</th>
-            <th>Estado</th>
-            <th>Dirección de Envío</th>
-            <th>Teléfono</th>
-            <th>Instrucciones</th>
-            <th>Fecha</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map((order) => (
-            <tr key={order._id}>
-              <td>{order._id}</td>
-              <td>{order.user || "N/A"}</td>
-              <td>${order.totalPrice}</td>
-              <td>
-                <select
-                  value={order.status}
-                  onChange={(e) =>
-                    handleStatusChange(order._id, e.target.value)
-                  }
-                >
-                  <option value="Pendiente">Pendiente</option>
-                  <option value="Completado">Completado</option>
-                </select>
-              </td>
-              <td>{order.shippingAddress}</td>
-              <td>{order.phone}</td>
-              <td>{order.instructions}</td>
-              <td>{new Date(order.createdAt).toLocaleString()}</td>
+      {loadingOrders ? (
+        <div className="spinner">Cargando pedidos...</div>
+      ) : ordersError ? (
+        <div className="error-message">{ordersError}</div>
+      ) : (
+        <table className="orders-table">
+          <thead>
+            <tr>
+              <th
+                className={`sortable ${
+                  sortConfig.key === "_id" ? sortConfig.direction : ""
+                }`}
+                onClick={() => handleSort("_id")}
+              >
+                ID Orden
+              </th>
+              <th
+                className={`sortable ${
+                  sortConfig.key === "user" ? sortConfig.direction : ""
+                }`}
+                onClick={() => handleSort("user")}
+              >
+                Usuario
+              </th>
+              <th
+                className={`sortable ${
+                  sortConfig.key === "totalPrice" ? sortConfig.direction : ""
+                }`}
+                onClick={() => handleSort("totalPrice")}
+              >
+                Total
+              </th>
+              <th
+                className={`sortable ${
+                  sortConfig.key === "status" ? sortConfig.direction : ""
+                }`}
+                onClick={() => handleSort("status")}
+              >
+                Estado
+              </th>
+              <th>Dirección de Envío</th>
+              <th>Teléfono</th>
+              <th>Instrucciones</th>
+              <th
+                className={`sortable ${
+                  sortConfig.key === "createdAt" ? sortConfig.direction : ""
+                }`}
+                onClick={() => handleSort("createdAt")}
+              >
+                Fecha
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {sortedOrders.map((order) => (
+              <tr key={order._id}>
+                <td>{order._id}</td>
+                <td>{order.user || "N/A"}</td>
+                <td>${order.totalPrice}</td>
+                <td>
+                  <select
+                    value={order.status}
+                    onChange={(e) =>
+                      handleStatusChange(order._id, e.target.value)
+                    }
+                  >
+                    <option value="Pendiente">Pendiente</option>
+                    <option value="Completado">Completado</option>
+                  </select>
+                </td>
+                <td>{order.shippingAddress}</td>
+                <td>{order.phone}</td>
+                <td>{order.instructions}</td>
+                <td>{new Date(order.createdAt).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add search, pagination size control, sorting, and error/loading states to admin dashboard
- improve dashboard responsiveness and add table sort indicators

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689284fcef20832d994bbb01413e2a32