### PR TITLE
frontend: add hero carousel and feature animations

### DIFF
--- a/frontend/src/components/HeroCarousel.js
+++ b/frontend/src/components/HeroCarousel.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "./ui";
+
+const HeroCarousel = ({ slides = [] }) => {
+  const [current, setCurrent] = useState(0);
+  const navigate = useNavigate();
+  const textRef = useRef(null);
+
+  useEffect(() => {
+    if (slides.length <= 1) return;
+    const interval = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % slides.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [slides.length]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("visible");
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+    if (textRef.current) {
+      observer.observe(textRef.current);
+    }
+    return () => observer.disconnect();
+  }, [current]);
+
+  return (
+    <div className="hero-carousel">
+      {slides.map((slide, index) => (
+        <div
+          key={index}
+          className={`hero-slide ${index === current ? "active" : ""}`}
+        >
+          <picture>
+            <source media="(max-width: 768px)" srcSet={slide.image.mobile} />
+            <source media="(min-width: 769px)" srcSet={slide.image.desktop} />
+            <img src={slide.image.desktop} alt={slide.alt} loading="lazy" />
+          </picture>
+          <div className="home-overlay">
+            <div
+              className="home-content fade-in-up"
+              ref={index === current ? textRef : null}
+            >
+              <h1>{slide.heading}</h1>
+              <p>{slide.text}</p>
+              <Button
+                className="home-cta"
+                onClick={() => navigate(slide.ctaLink)}
+              >
+                {slide.ctaText}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HeroCarousel;

--- a/frontend/src/css/HomePage.css
+++ b/frontend/src/css/HomePage.css
@@ -1,12 +1,30 @@
 @import "../design/tokens.css";
 
-.home-hero {
+.hero-carousel {
   position: relative;
   height: 100vh;
-  background: url("../imagenes/cajasdeplasticohome.jpg") center/cover no-repeat;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow: hidden;
+}
+
+.hero-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity var(--motion-slow) var(--motion-ease);
+}
+
+.hero-slide.active {
+  opacity: 1;
+}
+
+.hero-slide picture,
+.hero-slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .home-overlay {
@@ -23,6 +41,18 @@
   color: var(--color-surface);
   padding: var(--space-6);
   max-width: 700px;
+}
+
+.fade-in-up {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity var(--motion-medium) var(--motion-ease),
+    transform var(--motion-medium) var(--motion-ease);
+}
+
+.fade-in-up.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .home-content h1 {
@@ -88,6 +118,13 @@
 }
 
 .feature-card h3 {
+  color: var(--color-success);
+  margin-bottom: var(--space-2);
+}
+
+.feature-icon {
+  width: 40px;
+  height: 40px;
   color: var(--color-success);
   margin-bottom: var(--space-2);
 }
@@ -195,7 +232,11 @@
 /* ---------------------
    Responsive Adjustments
 ---------------------- */
-@media (max-width: 768px) {
+@media (max-width: 480px) {
+  .hero-carousel {
+    height: 60vh;
+  }
+
   .home-content h1 {
     font-size: calc(var(--font-size-xl) * 1.333);
   }
@@ -218,5 +259,22 @@
   .feature-card,
   .preview-item {
     width: 90%;
+  }
+}
+
+@media (min-width: 481px) and (max-width: 1024px) {
+  .hero-carousel {
+    height: 80vh;
+  }
+
+  .features,
+  .preview-gallery {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .feature-card,
+  .preview-item {
+    width: 45%;
   }
 }

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -1,46 +1,92 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import "../css/HomePage.css";
 import { Button } from "../components/ui";
+import Icon from "../icons/Icon";
+import HeroCarousel from "../components/HeroCarousel";
+
+const slides = [
+  {
+    image: {
+      mobile: "/imagenes/cajasdeplasticohome.jpg",
+      desktop: "/imagenes/cajasdeplasticohome.jpg",
+    },
+    heading: "Soluciones Sustentables para el Transporte Agrícola",
+    text: "RePlastiCos ofrece cajas de plástico reutilizables para frutas y verduras, ayudando a productores y empresas a reducir su huella ambiental.",
+    ctaText: "Ver Productos",
+    ctaLink: "/products",
+    alt: "Cajas de plástico reutilizables",
+  },
+  {
+    image: {
+      mobile: "/imagenes/reciclaje.jpg",
+      desktop: "/imagenes/reciclaje.jpg",
+    },
+    heading: "Economía circular para tu negocio",
+    text: "Opta por soluciones que cuidan el planeta y prolongan la vida útil de tus envases.",
+    ctaText: "Saber más",
+    ctaLink: "/about",
+    alt: "Proceso de reciclaje",
+  },
+];
+
+const features = [
+  {
+    title: "Reutilizables",
+    text: "Diseñadas para durar, reducen el desperdicio y los costos.",
+    icon: "star",
+  },
+  {
+    title: "Higiénicas",
+    text: "Fáciles de lavar, ideales para transportar alimentos frescos.",
+    icon: "lock",
+  },
+  {
+    title: "Sustentables",
+    text: "Fabricadas con materiales reciclables para un futuro más verde.",
+    icon: "leaf",
+  },
+];
 
 const HomePage = () => {
   const navigate = useNavigate();
+  const featureRefs = useRef([]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("visible");
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+    featureRefs.current.forEach((ref) => {
+      if (ref) observer.observe(ref);
+    });
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div className="home-page grid cols-1">
-      <section className="home-hero">
-        <div className="home-overlay">
-          <div className="home-content">
-            <h1>Soluciones Sustentables para el Transporte Agrícola</h1>
-            <p>
-              RePlastiCos ofrece cajas de plástico reutilizables para frutas y
-              verduras, ayudando a productores y empresas a reducir su huella
-              ambiental.
-            </p>
-            <Button className="home-cta" onClick={() => navigate("/products") }>
-              Ver Productos
-            </Button>
-          </div>
-        </div>
-      </section>
+      <HeroCarousel slides={slides} />
 
       <section className="features-section">
         <h2>¿Por qué elegir RePlastiCos?</h2>
         <div className="features">
-          <div className="feature-card">
-            <h3>Reutilizables</h3>
-            <p>Diseñadas para durar, reducen el desperdicio y los costos.</p>
-          </div>
-          <div className="feature-card">
-            <h3>Higiénicas</h3>
-            <p>Fáciles de lavar, ideales para transportar alimentos frescos.</p>
-          </div>
-          <div className="feature-card">
-            <h3>Sustentables</h3>
-            <p>
-              Fabricadas con materiales reciclables para un futuro más verde.
-            </p>
-          </div>
+          {features.map((feature, index) => (
+            <div
+              key={feature.title}
+              className="feature-card fade-in-up"
+              ref={(el) => (featureRefs.current[index] = el)}
+            >
+              <Icon name={feature.icon} className="feature-icon" />
+              <h3>{feature.title}</h3>
+              <p>{feature.text}</p>
+            </div>
+          ))}
         </div>
       </section>
 
@@ -52,19 +98,49 @@ const HomePage = () => {
         </p>
         <div className="preview-gallery">
           <div className="preview-item">
-            <img src="/imagenes/caja-estandar.jpg" alt="Caja estándar" />
+            <picture>
+              <source
+                srcSet="/imagenes/caja-estandar.jpg"
+                media="(min-width: 769px)"
+              />
+              <img
+                src="/imagenes/caja-estandar.jpg"
+                alt="Caja estándar"
+                loading="lazy"
+              />
+            </picture>
             <p>Caja estándar</p>
           </div>
           <div className="preview-item">
-            <img src="/imagenes/caja-ventilada.jpg" alt="Caja ventilada" />
+            <picture>
+              <source
+                srcSet="/imagenes/caja-ventilada.jpg"
+                media="(min-width: 769px)"
+              />
+              <img
+                src="/imagenes/caja-ventilada.jpg"
+                alt="Caja ventilada"
+                loading="lazy"
+              />
+            </picture>
             <p>Caja ventilada</p>
           </div>
           <div className="preview-item">
-            <img src="/imagenes/caja-apilable.jpg" alt="Caja apilable" />
+            <picture>
+              <source
+                srcSet="/imagenes/caja-apilable.jpg"
+                media="(min-width: 769px)"
+              />
+              <img
+                src="/imagenes/caja-apilable.jpg"
+                alt="Caja apilable"
+                loading="lazy"
+              />
+            </picture>
             <p>Caja apilable</p>
           </div>
         </div>
-        <Button className="home-cta" onClick={() => navigate("/products") }>
+        <Button className="home-cta" onClick={() => navigate("/products")}>
           Ver catálogo completo
         </Button>
       </section>
@@ -80,7 +156,7 @@ const HomePage = () => {
       <section className="cta-final">
         <h2>Únete al cambio</h2>
         <p>Regístrate ahora y comienza a transformar tu logística.</p>
-        <Button className="home-cta" onClick={() => navigate("/register") }>
+        <Button className="home-cta" onClick={() => navigate("/register")}>
           Crear cuenta
         </Button>
       </section>


### PR DESCRIPTION
## Summary
- replace static hero with a sliding `HeroCarousel` component and responsive images
- map feature cards from data with icons and lazy loaded previews
- add fade-in animations and responsive breakpoints for hero and features

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`
- `cd ../backend && node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68928e467404832d80f16277f5e23eec