### PR TITLE
frontend: add product card quick view and badges

### DIFF
--- a/frontend/src/components/ProductCard.js
+++ b/frontend/src/components/ProductCard.js
@@ -1,0 +1,116 @@
+import { Link } from "react-router-dom";
+import React, { useState, useRef, useEffect } from "react";
+import Icon from "../icons/Icon";
+import QuickViewModal from "./QuickViewModal";
+
+function ProductCard({ product }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef(null);
+  const imgRef = useRef(null);
+
+  useEffect(() => {
+    const img = imgRef.current;
+    if (!img) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("loaded");
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: "100px" });
+    observer.observe(img);
+    return () => observer.disconnect();
+  }, []);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    if (buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  };
+
+  const handleWishlist = () => {
+    const list = JSON.parse(localStorage.getItem("wishlist") || "[]");
+    if (!list.includes(product._id)) {
+      localStorage.setItem("wishlist", JSON.stringify([...list, product._id]));
+    }
+  };
+
+  const getBadge = () => {
+    if (product.stock === 0) {
+      return "Agotado";
+    }
+    if (product.onSale) {
+      return "Oferta";
+    }
+    const created = new Date(product.createdAt);
+    if (Date.now() - created.getTime() < 1000 * 60 * 60 * 24 * 30) {
+      return "Nuevo";
+    }
+    return null;
+  };
+
+  const badge = getBadge();
+  const rating = product.rating || 0;
+
+  return (
+    <div className="product-card">
+      <Link to={`/product/${product._id}`} className="product-link">
+        <div className="image-wrapper">
+          {product.imageUrl ? (
+            <img
+              ref={imgRef}
+              src={product.imageUrl}
+              alt={product.name}
+              loading="lazy"
+              className="product-image lazy"
+            />
+          ) : (
+            <div className="no-image">Sin imagen</div>
+          )}
+          {badge && (
+            <span className={`product-badge badge-${badge.toLowerCase()}`}>
+              {badge}
+            </span>
+          )}
+        </div>
+        <h3>{product.name}</h3>
+      </Link>
+      <div className="product-rating" aria-label={`Calificación ${rating} de 5`}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Icon
+            key={i}
+            name="star"
+            className={i < rating ? "star-icon filled" : "star-icon"}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+      <button
+        className="wishlist-btn"
+        onClick={handleWishlist}
+        aria-label={`Añadir ${product.name} a la lista de deseos`}
+      >
+        Añadir a la lista de deseos
+      </button>
+      <button
+        ref={buttonRef}
+        className="quick-view-btn"
+        onClick={handleOpen}
+        aria-label={`Vista rápida de ${product.name}`}
+      >
+        Vista rápida
+      </button>
+      <QuickViewModal product={product} isOpen={isOpen} onClose={handleClose} />
+    </div>
+  );
+}
+
+export default ProductCard;

--- a/frontend/src/components/QuickViewModal.js
+++ b/frontend/src/components/QuickViewModal.js
@@ -1,0 +1,41 @@
+import React, { useContext } from "react";
+import Modal from "./ui/Modal";
+import { CartContext } from "../context/CartContext";
+
+function QuickViewModal({ product, isOpen, onClose }) {
+  const { addToCart } = useContext(CartContext);
+  if (!product) {
+    return null;
+  }
+
+  const handleAdd = () => {
+    addToCart(product);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="quick-view-content">
+        {product.imageUrl && (
+          <img
+            src={product.imageUrl}
+            alt={product.name}
+            loading="lazy"
+            className="product-image"
+          />
+        )}
+        <h2 id="quick-view-title">{product.name}</h2>
+        <p>{product.description}</p>
+        <strong>${product.price}</strong>
+        <button
+          onClick={handleAdd}
+          aria-label={`Añadir ${product.name} al carrito`}
+        >
+          Añadir al carrito
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export default QuickViewModal;

--- a/frontend/src/css/ProductsPage.css
+++ b/frontend/src/css/ProductsPage.css
@@ -138,3 +138,65 @@
   text-align: center;
   margin-top: var(--space-6);
 }
+.image-wrapper {
+  position: relative;
+}
+
+.product-badge {
+  position: absolute;
+  top: var(--space-2);
+  left: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: 4px;
+  color: var(--color-surface);
+  font-size: var(--font-size-sm);
+}
+
+.badge-nuevo {
+  background-color: var(--color-primary);
+}
+
+.badge-oferta {
+  background-color: var(--color-warning);
+  color: var(--color-text);
+}
+
+.badge-agotado {
+  background-color: var(--color-danger);
+}
+
+.lazy {
+  opacity: 0;
+  transition: opacity var(--motion-slow) var(--motion-ease);
+}
+
+.lazy.loaded {
+  opacity: 1;
+}
+
+.product-rating {
+  display: flex;
+  justify-content: center;
+  gap: 2px;
+  margin-bottom: var(--space-4);
+}
+
+.star-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-gray-700);
+}
+
+.star-icon.filled {
+  color: var(--color-warning);
+}
+
+.wishlist-btn {
+  margin-bottom: var(--space-3);
+}
+
+.product-link {
+  text-decoration: none;
+  color: inherit;
+}
+

--- a/frontend/src/pages/ProductsPage.js
+++ b/frontend/src/pages/ProductsPage.js
@@ -1,12 +1,10 @@
 // src/pages/ProductsPage.js
-import React, { useEffect, useState, useContext } from "react";
-import { Link } from "react-router-dom";
-import { CartContext } from "../context/CartContext";
+import React, { useEffect, useState } from "react";
 import "../css/ProductsPage.css";
-import { Button, Card, CardGrid } from "../components/ui";
+import { CardGrid } from "../components/ui";
+import ProductCard from "../components/ProductCard";
 
 const ProductsPage = () => {
-  const { addToCart } = useContext(CartContext);
   const [products, setProducts] = useState([]);
   const [categories, setCategories] = useState([]);
   const [search, setSearch] = useState("");
@@ -114,25 +112,7 @@ const ProductsPage = () => {
         ) : sorted.length > 0 ? (
           <CardGrid className="products-grid">
             {sorted.map((product) => (
-              <Card key={product._id} className="product-card">
-                <Link to={`/product/${product._id}`}>
-                  {product.imageUrl ? (
-                    <img
-                      src={product.imageUrl}
-                      alt={product.name}
-                      className="product-image"
-                    />
-                  ) : (
-                    <div className="no-image">Sin imagen</div>
-                  )}
-                  <h3>{product.name}</h3>
-                </Link>
-                <p>{product.description.substring(0, 50)}...</p>
-                <strong>${product.price}</strong>
-                <Button onClick={() => addToCart(product)}>
-                  Añadir al carrito
-                </Button>
-              </Card>
+              <ProductCard key={product._id} product={product} />
             ))}
           </CardGrid>
         ) : (


### PR DESCRIPTION
## Summary
- build reusable ProductCard with lazy-loaded images, badges, rating stars and wishlist + quick view actions
- implement QuickViewModal for accessible product details and cart action
- style product badges and lazy-image fade-ins

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`
- `cd ../backend && node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_6892a09633f4832da28166508384b871