### PR TITLE
Add multi-step checkout with quote and address autocomplete

### DIFF
--- a/frontend/src/css/CheckoutForm.css
+++ b/frontend/src/css/CheckoutForm.css
@@ -85,3 +85,48 @@
   text-align: center;
   margin-bottom: var(--space-4);
 }
+
+.progress-bar {
+  background-color: var(--color-gray-300);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: var(--space-5);
+  height: 8px;
+}
+
+.progress {
+  background-color: var(--color-primary);
+  height: 100%;
+  width: 0;
+  transition: width 0.3s ease;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.suggestions {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0;
+  border: 1px solid var(--color-gray-600);
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.suggestions li {
+  padding: var(--space-2);
+  cursor: pointer;
+  background-color: var(--color-surface);
+}
+
+.suggestions li:hover {
+  background-color: var(--color-gray-100);
+}
+
+.review-card {
+  margin-bottom: var(--space-5);
+}

--- a/frontend/src/pages/CheckoutForm.js
+++ b/frontend/src/pages/CheckoutForm.js
@@ -1,60 +1,166 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { CartContext } from "../context/CartContext";
+import { AuthContext } from "../context/AuthContext";
 import "../css/CheckoutForm.css";
 import { Button, Card, Form, TextInput } from "../components/ui";
 
 const CheckoutForm = () => {
   const { cartItems, clearCart } = useContext(CartContext);
+  const { userInfo } = useContext(AuthContext);
   const navigate = useNavigate();
+  const [step, setStep] = useState(1);
   const [formData, setFormData] = useState({
-    shippingAddress: "",
+    name: "",
+    email: "",
+    company: "",
     phone: "",
+    shippingAddress: "",
+    deliveryMethod: "standard",
+    paymentMethod: "",
     instructions: "",
   });
-  const [error, setError] = useState(null);
+  const [errors, setErrors] = useState({});
+  const [addressSuggestions, setAddressSuggestions] = useState([]);
+  const [quote, setQuote] = useState(null);
 
-  // Función para calcular el total de la compra
-  const totalPrice = cartItems.reduce(
-    (total, item) => total + item.product.price * item.quantity,
-    0
-  );
+  useEffect(() => {
+    const saved = localStorage.getItem("checkoutData");
+    if (saved) {
+      setFormData((prev) => ({ ...prev, ...JSON.parse(saved) }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (userInfo) {
+      setFormData((prev) => ({
+        ...prev,
+        name: userInfo.name || "",
+        email: userInfo.email || "",
+      }));
+    }
+  }, [userInfo]);
+
+  useEffect(() => {
+    localStorage.setItem("checkoutData", JSON.stringify(formData));
+  }, [formData]);
+
+  useEffect(() => {
+    const fetchQuote = async () => {
+      try {
+        const payload = {
+          products: cartItems.map((item) => ({
+            product: item.product._id,
+            quantity: item.quantity,
+          })),
+          deliveryMethod: formData.deliveryMethod,
+        };
+        const res = await fetch("http://localhost:5000/api/orders/quote", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        setQuote(data);
+      } catch (err) {
+        console.error("Error fetching quote:", err);
+      }
+    };
+    if (cartItems.length) {
+      fetchQuote();
+    }
+  }, [cartItems, formData.deliveryMethod]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const handleAddressChange = (e) => {
+    const value = e.target.value;
+    setFormData({ ...formData, shippingAddress: value });
+    fetchAddressSuggestions(value);
+  };
 
-    // Calcular la cantidad total de unidades
-    const totalUnits = cartItems.reduce((acc, item) => acc + item.quantity, 0);
-
-    // Validar que la cantidad mínima sea 50
-    if (totalUnits < 50) {
-      setError("La compra mínima es de 50 unidades.");
+  const fetchAddressSuggestions = async (query) => {
+    if (query.length < 3) {
+      setAddressSuggestions([]);
       return;
     }
+    try {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
+          query
+        )}`
+      );
+      const data = await res.json();
+      setAddressSuggestions(data.map((item) => item.display_name));
+    } catch (err) {
+      console.error("Error fetching address:", err);
+    }
+  };
 
-    // Prepara el objeto de la orden, agregando información extra
+  const selectAddress = (address) => {
+    setFormData({ ...formData, shippingAddress: address });
+    setAddressSuggestions([]);
+  };
+
+  const validateStep = () => {
+    const newErrors = {};
+    if (step === 1) {
+      if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(formData.email)) {
+        newErrors.email = "Email inválido";
+      }
+      if (!/^\+?[0-9]{7,15}$/.test(formData.phone)) {
+        newErrors.phone = "Teléfono inválido";
+      }
+    }
+    if (step === 2 && !formData.shippingAddress) {
+      newErrors.shippingAddress = "Dirección requerida";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const nextStep = () => {
+    if (validateStep()) {
+      setStep(step + 1);
+    }
+  };
+
+  const prevStep = () => {
+    setStep(step - 1);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const totalUnits = cartItems.reduce((acc, item) => acc + item.quantity, 0);
+    if (totalUnits < 50) {
+      setErrors({ general: "La compra mínima es de 50 unidades." });
+      return;
+    }
     const orderData = {
+      name: formData.name,
+      email: formData.email,
+      company: formData.company,
       shippingAddress: formData.shippingAddress,
       phone: formData.phone,
+      deliveryMethod: formData.deliveryMethod,
+      paymentMethod: formData.paymentMethod,
       instructions: formData.instructions,
       products: cartItems.map((item) => ({
         product: item.product._id,
         quantity: item.quantity,
       })),
     };
-
     fetch("http://localhost:5000/api/orders", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(orderData),
     })
       .then((res) => res.json())
-      .then((data) => {
+      .then(() => {
+        localStorage.removeItem("checkoutData");
         navigate("/confirmation", {
           state: { success: true, message: "Pedido realizado con éxito" },
         });
@@ -62,13 +168,21 @@ const CheckoutForm = () => {
       })
       .catch((err) => {
         console.error("Error en el checkout:", err);
-        setError("Ocurrió un error al procesar el pedido.");
+        setErrors({ general: "Ocurrió un error al procesar el pedido." });
       });
   };
+
+  const totalPrice = cartItems.reduce(
+    (total, item) => total + item.product.price * item.quantity,
+    0
+  );
 
   return (
     <div className="checkout-form-container grid cols-1">
       <h1>Formulario de Pago</h1>
+      <div className="progress-bar">
+        <div className="progress" style={{ width: `${(step / 3) * 100}%` }}></div>
+      </div>
       <Card className="order-summary">
         <h2>Resumen del Pedido</h2>
         <ul>
@@ -79,42 +193,169 @@ const CheckoutForm = () => {
             </li>
           ))}
         </ul>
-        <h3>Total: ${totalPrice}</h3>
+        {quote && (
+          <div className="quote">
+            <p>Subtotal: ${quote.subtotal}</p>
+            <p>Envío: ${quote.deliveryFee}</p>
+            <p>Total estimado: ${quote.total}</p>
+          </div>
+        )}
+        {!quote && <h3>Total: ${totalPrice}</h3>}
       </Card>
-      {error && <div className="error">{error}</div>}
+      {errors.general && <div className="error">{errors.general}</div>}
       <Form onSubmit={handleSubmit} className="checkout-form">
-        <TextInput
-          label="Dirección de Envío"
-          id="shippingAddress"
-          name="shippingAddress"
-          type="text"
-          value={formData.shippingAddress}
-          onChange={handleChange}
-          required
-        />
-        <TextInput
-          label="Teléfono"
-          id="phone"
-          name="phone"
-          type="text"
-          value={formData.phone}
-          onChange={handleChange}
-          required
-        />
-        <div className="form-group">
-          <label htmlFor="instructions">
-            Instrucciones Adicionales (opcional)
-          </label>
-          <textarea
-            id="instructions"
-            name="instructions"
-            value={formData.instructions}
-            onChange={handleChange}
-          ></textarea>
-        </div>
-        <Button type="submit" className="submit-button">
-          Confirmar Pedido
-        </Button>
+        {step === 1 && (
+          <>
+            <TextInput
+              label="Nombre"
+              id="name"
+              name="name"
+              type="text"
+              value={formData.name}
+              onChange={handleChange}
+              required
+            />
+            {errors.name && <div className="error">{errors.name}</div>}
+            <TextInput
+              label="Email"
+              id="email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+            />
+            {errors.email && <div className="error">{errors.email}</div>}
+            <TextInput
+              label="Teléfono"
+              id="phone"
+              name="phone"
+              type="text"
+              value={formData.phone}
+              onChange={handleChange}
+              required
+            />
+            {errors.phone && <div className="error">{errors.phone}</div>}
+            <TextInput
+              label="Compañía"
+              id="company"
+              name="company"
+              type="text"
+              value={formData.company}
+              onChange={handleChange}
+            />
+            <div className="form-actions">
+              <Button type="button" onClick={nextStep}>
+                Siguiente
+              </Button>
+            </div>
+          </>
+        )}
+        {step === 2 && (
+          <>
+            <TextInput
+              label="Dirección de Envío"
+              id="shippingAddress"
+              name="shippingAddress"
+              type="text"
+              value={formData.shippingAddress}
+              onChange={handleAddressChange}
+              required
+            />
+            {errors.shippingAddress && (
+              <div className="error">{errors.shippingAddress}</div>
+            )}
+            {addressSuggestions.length > 0 && (
+              <ul className="suggestions">
+                {addressSuggestions.map((addr) => (
+                  <li key={addr} onClick={() => selectAddress(addr)}>
+                    {addr}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="form-group">
+              <label htmlFor="deliveryMethod">Método de entrega</label>
+              <select
+                id="deliveryMethod"
+                name="deliveryMethod"
+                value={formData.deliveryMethod}
+                onChange={handleChange}
+              >
+                <option value="standard">Estándar</option>
+                <option value="express">Express</option>
+              </select>
+            </div>
+            <div className="form-group">
+              <label htmlFor="paymentMethod">Método de pago</label>
+              <select
+                id="paymentMethod"
+                name="paymentMethod"
+                value={formData.paymentMethod}
+                onChange={handleChange}
+              >
+                <option value="">Seleccionar</option>
+                <option value="credit">Tarjeta de crédito</option>
+                <option value="bank">Transferencia bancaria</option>
+              </select>
+            </div>
+            <div className="form-group">
+              <label htmlFor="instructions">
+                Instrucciones Adicionales (opcional)
+              </label>
+              <textarea
+                id="instructions"
+                name="instructions"
+                value={formData.instructions}
+                onChange={handleChange}
+              ></textarea>
+            </div>
+            <div className="form-actions">
+              <Button type="button" onClick={prevStep}>
+                Atrás
+              </Button>
+              <Button type="button" onClick={nextStep}>
+                Siguiente
+              </Button>
+            </div>
+          </>
+        )}
+        {step === 3 && (
+          <>
+            <Card className="review-card">
+              <h2>Revisión</h2>
+              <p>
+                <strong>Nombre:</strong> {formData.name}
+              </p>
+              <p>
+                <strong>Email:</strong> {formData.email}
+              </p>
+              <p>
+                <strong>Teléfono:</strong> {formData.phone}
+              </p>
+              <p>
+                <strong>Compañía:</strong> {formData.company}
+              </p>
+              <p>
+                <strong>Dirección:</strong> {formData.shippingAddress}
+              </p>
+              <p>
+                <strong>Método de entrega:</strong> {formData.deliveryMethod}
+              </p>
+              <p>
+                <strong>Método de pago:</strong> {formData.paymentMethod || "No seleccionado"}
+              </p>
+            </Card>
+            <div className="form-actions">
+              <Button type="button" onClick={prevStep}>
+                Atrás
+              </Button>
+              <Button type="submit" className="submit-button">
+                Confirmar Pedido
+              </Button>
+            </div>
+          </>
+        )}
       </Form>
     </div>
   );


### PR DESCRIPTION
## Summary
- Extend checkout to a three-step flow with contact, shipping/payment, and review steps, persisting data and autofilling from profile
- Add address autocomplete, client-side validation, real-time quote, and placeholder payment method
- Style checkout with progress bar, suggestion list, and review card

## Testing
- `cd backend && yarn install`
- `node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*
- `cd ../frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6892a571a8d8832d8f8bf9e3af0ad2aa