### PR TITLE
Maintain AboutUs header spacing without banner

### DIFF
--- a/frontend/src/css/AboutUs.css
+++ b/frontend/src/css/AboutUs.css
@@ -13,20 +13,27 @@
   position: relative;
   margin-bottom: calc(var(--space-6) + var(--space-4));
   text-align: center;
+  min-height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-banner picture {
+  position: absolute;
+  inset: 0;
 }
 
 .header-banner picture img {
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   border-radius: 16px;
 }
 
 .header-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   color: var(--color-surface);
+  z-index: 1;
 }
 
 .header-title {

--- a/frontend/src/pages/AboutUs.js
+++ b/frontend/src/pages/AboutUs.js
@@ -11,6 +11,11 @@ import JoinUs from "../components/JoinUs";
 import "../css/AboutUs.css";
 
 const AboutUs = () => {
+  const banner = {
+    desktop: "https://via.placeholder.com/1200x400",
+    mobile: "https://via.placeholder.com/800x300"
+  };
+
   useEffect(() => {
     const sections = document.querySelectorAll(".fade-in-section");
     const observer = new IntersectionObserver(
@@ -30,17 +35,23 @@ const AboutUs = () => {
 
   return (
     <section className="about-container">
-      <header className="header-banner fade-in-section">
-        <picture>
-          <source
-            srcSet="https://via.placeholder.com/800x300"
-            media="(max-width: 600px)"
-          />
-          <img
-            src="https://via.placeholder.com/1200x400"
-            alt="Banner RePlastiCos"
-          />
-        </picture>
+      <header
+        className="header-banner fade-in-section"
+        style={!banner ? { backgroundColor: "var(--color-background-light)" } : undefined}
+      >
+        {banner && (
+          <picture>
+            {banner.mobile && (
+              <source
+                srcSet={banner.mobile}
+                media="(max-width: 600px)"
+              />
+            )}
+            {banner.desktop && (
+              <img src={banner.desktop} alt="Banner RePlastiCos" />
+            )}
+          </picture>
+        )}
         <div className="header-text">
           <h1 className="header-title">Sobre RePlastiCos</h1>
           <p className="header-subtitle">


### PR DESCRIPTION
## Summary
- ensure AboutUs header keeps vertical space via flexbox and min-height
- center header text without absolute positioning
- render banner image conditionally with background fallback

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `cd frontend && yarn test --watchAll=false`
- `cd frontend && yarn build`
- `cd backend && node server.js` *(fails: querySrv ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6892a75ba280832dbe4bdc874b6c7d47