### PR TITLE
frontend: default product list to array in ManageProducts

### DIFF
--- a/frontend/src/pages/ManageProducts.js
+++ b/frontend/src/pages/ManageProducts.js
@@ -11,7 +11,7 @@ const ManageProducts = () => {
   const fetchProducts = () => {
     fetch("http://localhost:5000/api/products")
       .then((res) => res.json())
-      .then((data) => setProducts(data))
+      .then((data) => setProducts(data.products || []))
       .catch((err) => console.error("Error fetching products:", err));
   };
 


### PR DESCRIPTION
## Summary
- ensure ManageProducts uses data.products when fetching product list, defaulting to empty array

## Testing
- `yarn test --watchAll=false`
- `yarn build`
- `node server.js` (fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)


------
https://chatgpt.com/codex/tasks/task_e_6892afa5432c832db8ed979976b847d9