### PR TITLE
frontend: wrap orders table in scrollable container

### DIFF
--- a/frontend/src/css/AdminDashboard.css
+++ b/frontend/src/css/AdminDashboard.css
@@ -68,9 +68,15 @@
   gap: var(--space-2);
 }
 
+.orders-table-wrapper {
+  overflow-x: auto;
+  width: 100%;
+}
+
 .orders-table {
   width: 100%;
   border-collapse: collapse;
+  min-width: 1000px;
 }
 
 .orders-table th,
@@ -123,10 +129,5 @@
   .pagination {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .orders-table {
-    display: block;
-    overflow-x: auto;
   }
 }

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -430,8 +430,9 @@ const AdminDashboard = () => {
       ) : ordersError ? (
         <div className="error-message">{ordersError}</div>
       ) : (
-        <table className="orders-table">
-          <thead>
+        <div className="orders-table-wrapper">
+          <table className="orders-table">
+            <thead>
             <tr>
               <th
                 className={`sortable ${
@@ -541,6 +542,7 @@ const AdminDashboard = () => {
             </tr>
           </tbody>
         </table>
+      </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap AdminDashboard orders table in scrollable container
- add styles for orders table wrapper and min-width

## Testing
- `node server.js` (fails to connect to MongoDB)
- `npm test --prefix frontend -- --watchAll=false`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6892b0e71b90832dac4ccbeb4dabbaaf