### PR TITLE
backend: use product names in Excel exports

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -60,7 +60,8 @@ export const createOrder = async (req, res) => {
       status: "Pendiente",
     });
 
-    saveOrderToExcel(order);
+    const orderForExcel = { ...order.toObject(), products: detailedProducts };
+    saveOrderToExcel(orderForExcel);
 
     return res.status(201).json(order);
   } catch (error) {

--- a/backend/services/excelService.js
+++ b/backend/services/excelService.js
@@ -49,7 +49,7 @@ export function saveOrderToExcel(order) {
   const orderId = order._id.toString();
   const userId = order.user ? order.user.toString() : "N/A";
   const productsStr = order.products
-    .map((p) => `(${p.product}, cant: ${p.quantity})`)
+    .map((p) => `(${p.product.name || p.product}, cant: ${p.quantity})`)
     .join(", ");
   const totalPrice = order.totalPrice;
   const status = order.status || "Pendiente";
@@ -116,8 +116,7 @@ export function exportOrdersToExcel(orders, filePath) {
   const data = orders.map((order) => {
     const productsStr = order.products
       .map(
-        (p) =>
-          `(${p.product._id || p.product}, cant: ${p.quantity})`
+        (p) => `(${p.product.name || p.product}, cant: ${p.quantity})`
       )
       .join(", ");
     return [


### PR DESCRIPTION
## Summary
- replace product IDs with names in Excel exports
- pass populated product data when saving a new order

## Testing
- `cd backend && yarn install`
- `node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*
- `cd frontend && yarn install`
- `yarn build`
- `yarn test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892b2687bfc832da88f0dcf0edbb862