### PR TITLE
frontend: refine navbar layout

### DIFF
--- a/frontend/src/components/AdminNavbar.js
+++ b/frontend/src/components/AdminNavbar.js
@@ -11,12 +11,18 @@ const AdminNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
-  const menuItems = [
+  const primaryItems = [
     { to: "/manage-products", label: "Administrar Productos" },
     { to: "/admin", label: "Dashboard" },
   ];
 
-  return <Navbar menuItems={menuItems} onLogout={handleLogout} />;
+  return (
+    <Navbar
+      primaryItems={primaryItems}
+      utilityItems={[]}
+      onLogout={handleLogout}
+    />
+  );
 };
 
 AdminNavbar.propTypes = {

--- a/frontend/src/components/GuestNavbar.js
+++ b/frontend/src/components/GuestNavbar.js
@@ -6,18 +6,22 @@ import { CartContext } from "../context/CartContext";
 const GuestNavbar = () => {
   const { cartItems } = useContext(CartContext);
 
-  const menuItems = [
+  const primaryItems = [
     { to: "/", label: "Inicio", end: true },
     { to: "/about", label: "Nosotros" },
     { to: "/products", label: "Tienda" },
     { to: "/contact", label: "Contacto" },
+  ];
+
+  const utilityItems = [
     { to: "/login", label: "Login" },
-    { to: "/register", label: "Registro" },
+    { to: "/register", label: "Registro", cta: true },
   ];
 
   return (
     <Navbar
-      menuItems={menuItems}
+      primaryItems={primaryItems}
+      utilityItems={utilityItems}
       showCart
       cartCount={cartItems.length}
     />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -4,7 +4,13 @@ import { Link, NavLink } from "react-router-dom";
 import "../css/Navbar.css";
 import { Bars3Icon } from "@heroicons/react/24/solid";
 
-const Navbar = ({ menuItems, showCart = false, cartCount = 0, onLogout }) => {
+const Navbar = ({
+  primaryItems,
+  utilityItems = [],
+  showCart = false,
+  cartCount = 0,
+  onLogout,
+}) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuId = useId();
   const navRef = useRef(null);
@@ -92,50 +98,65 @@ const Navbar = ({ menuItems, showCart = false, cartCount = 0, onLogout }) => {
           </span>
         </button>
         <nav className="navbar-menu">
-          <ul
+          <div
             id={menuId}
             ref={menuRef}
             className={`navbar-links ${menuOpen ? "open" : ""}`}
           >
-            {menuItems.map((item, index) => (
-              <li key={item.to}>
-                <NavLink
-                  to={item.to}
-                  end={item.end}
-                  onClick={handleLinkClick}
-                  ref={index === 0 ? firstItemRef : null}
-                >
-                  {item.label}
-                </NavLink>
-              </li>
-            ))}
-            {showCart && (
-              <li>
-                <NavLink
-                  to="/cart"
-                  onClick={handleLinkClick}
-                  aria-label={cartLabel}
-                >
-                  <span className="cart-link-content">
-                    Carrito
-                    {cartCount > 0 && (
-                      <span className="cart-badge">{cartCount}</span>
-                    )}
-                    <span className="sr-only" aria-live="polite">
-                      {`Cart, ${cartCount} item${cartCount === 1 ? "" : "s"}`}
+            <ul className="navbar-primary">
+              {primaryItems.map((item, index) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    end={item.end}
+                    onClick={handleLinkClick}
+                    ref={index === 0 ? firstItemRef : null}
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+            <ul className="navbar-utilities">
+              {utilityItems.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    onClick={handleLinkClick}
+                    className={item.cta ? "navbar-cta" : undefined}
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+              {showCart && (
+                <li>
+                  <NavLink
+                    to="/cart"
+                    onClick={handleLinkClick}
+                    aria-label={cartLabel}
+                  >
+                    <span className="cart-link-content">
+                      Carrito
+                      {cartCount > 0 && (
+                        <span className="cart-badge">{cartCount}</span>
+                      )}
+                      <span className="sr-only" aria-live="polite">
+                        {`Cart, ${cartCount} item${cartCount === 1 ? "" : "s"}`}
+                      </span>
                     </span>
-                  </span>
-                </NavLink>
-              </li>
-            )}
-            {onLogout && (
-              <li>
-                <button onClick={handleLogout} className="logout-button">
-                  Logout
-                </button>
-              </li>
-            )}
-          </ul>
+                  </NavLink>
+                </li>
+              )}
+              {onLogout && (
+                <li>
+                  <button onClick={handleLogout} className="logout-button">
+                    Logout
+                  </button>
+                </li>
+              )}
+            </ul>
+          </div>
         </nav>
       </div>
     </header>
@@ -143,13 +164,20 @@ const Navbar = ({ menuItems, showCart = false, cartCount = 0, onLogout }) => {
 };
 
 Navbar.propTypes = {
-  menuItems: PropTypes.arrayOf(
+  primaryItems: PropTypes.arrayOf(
     PropTypes.shape({
       to: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
       end: PropTypes.bool,
     })
   ).isRequired,
+  utilityItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      to: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      cta: PropTypes.bool,
+    })
+  ),
   showCart: PropTypes.bool,
   cartCount: PropTypes.number,
   onLogout: PropTypes.func,

--- a/frontend/src/components/UserNavbar.js
+++ b/frontend/src/components/UserNavbar.js
@@ -13,7 +13,7 @@ const UserNavbar = ({ onLogout }) => {
     navigate("/");
   };
 
-  const menuItems = [
+  const primaryItems = [
     { to: "/", label: "Inicio", end: true },
     { to: "/about", label: "Nosotros" },
     { to: "/products", label: "Tienda" },
@@ -22,7 +22,8 @@ const UserNavbar = ({ onLogout }) => {
 
   return (
     <Navbar
-      menuItems={menuItems}
+      primaryItems={primaryItems}
+      utilityItems={[]}
       showCart
       cartCount={cartItems.length}
       onLogout={handleLogout}

--- a/frontend/src/css/Navbar.css
+++ b/frontend/src/css/Navbar.css
@@ -1,10 +1,9 @@
 @import "../design/tokens.css";
 
-
 .navbar {
-  background: linear-gradient(90deg, var(--color-success), var(--color-success-dark));
-  border-bottom: 1px solid var(--color-border);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  background-color: var(--color-text);
+  border-bottom: 1px solid #2B2B2B;
+  box-shadow: none;
   font-family: var(--font-family-base);
   position: sticky;
   top: 0;
@@ -16,8 +15,9 @@
   align-items: center;
   justify-content: space-between;
   max-width: 1200px;
+  height: 64px;
   margin: 0 auto;
-  padding: var(--space-3) var(--space-5);
+  padding: 0 var(--space-5);
 }
 
 .navbar-brand {
@@ -35,45 +35,68 @@
   height: 32px;
 }
 
+.navbar-menu {
+  flex: 1;
+}
+
 .navbar-links {
   display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.navbar-primary,
+.navbar-utilities {
+  display: flex;
+  align-items: center;
   gap: var(--space-5);
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.navbar-links li a {
+.navbar-utilities {
+  margin-left: auto;
+}
+
+.navbar-links a {
   color: var(--color-surface);
   text-decoration: none;
   font-size: var(--font-size-md);
   padding: var(--space-2) var(--space-1);
   position: relative;
-  transition: color 0.2s ease;
+  transition: color var(--motion-fast) var(--motion-ease);
+  display: flex;
+  align-items: center;
 }
 
-.navbar-links li a:focus-visible {
-  outline: 3px solid var(--color-focus-outline);
-  outline-offset: 2px;
+.navbar-links a:hover,
+.navbar-links a.active {
+  color: var(--color-secondary);
 }
 
-.navbar-links li a:hover,
-.navbar-links li a.active {
-  color: var(--color-background-lighter);
-}
-
-.navbar-links li a.active::after {
+.navbar-links a.active::after {
   content: "";
   position: absolute;
   left: 0;
-  bottom: -6px;
+  bottom: -4px;
   width: 100%;
   height: 2px;
-  background-color: var(--color-background-lighter);
+  background-color: var(--color-secondary);
   border-radius: 4px;
 }
 
-/* Responsive (optional mobile nav later) */
+.navbar-cta {
+  background-color: var(--color-primary);
+  color: var(--color-surface);
+  padding: var(--space-2) var(--space-4);
+  border-radius: 4px;
+}
+
+.navbar-cta:hover {
+  background-color: var(--color-primary-dark);
+}
+
 .navbar-toggle {
   display: none;
   background: none;
@@ -82,7 +105,10 @@
   cursor: pointer;
 }
 
-.navbar-toggle:focus-visible {
+.navbar-links a:focus-visible,
+.navbar-toggle:focus-visible,
+.logout-button:focus-visible,
+.navbar-cta:focus-visible {
   outline: 3px solid var(--color-focus-outline);
   outline-offset: 2px;
 }
@@ -101,6 +127,17 @@
   .navbar-links.open {
     display: flex;
   }
+
+  .navbar-primary,
+  .navbar-utilities {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-4);
+  }
+
+  .navbar-utilities {
+    margin-left: 0;
+  }
 }
 
 .cart-link-content {
@@ -108,7 +145,7 @@
   align-items: center;
   gap: var(--space-2);
   position: relative;
-  padding-top: 2px; /* adjust if needed */
+  padding-top: 2px;
 }
 
 .cart-icon {
@@ -122,7 +159,7 @@
 .cart-badge {
   position: absolute;
   top: -6px;
-  right: -10px; /* was 'left: 12px' */
+  right: -10px;
   background-color: var(--color-danger);
   color: var(--color-surface);
   border-radius: 50%;
@@ -130,10 +167,6 @@
   font-size: var(--space-3);
   font-weight: bold;
   z-index: 10;
-}
-.navbar-links li a {
-  display: flex;
-  align-items: center;
 }
 
 .logout-button {
@@ -143,7 +176,7 @@
   padding: var(--space-1) var(--space-3);
   border-radius: 4px;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color var(--motion-fast) var(--motion-ease);
 }
 
 .logout-button:hover {


### PR DESCRIPTION
## Summary
- separate primary navigation from utility actions and optional cart/logout
- add consistent hover, active, and CTA styles with unified accent color
- streamline navbar spacing and remove heavy shadows for a cleaner header

## Testing
- `yarn test --watchAll=false`
- `node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_689e37b02910832db25f1959deb82bbb