### PR TITLE
frontend: consolidate accent color

### DIFF
--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -8,11 +8,13 @@ Tokens centralize colors, spacing, typography, and motion values. They are defin
 
 ### Colors
 - `--color-primary` `#28a745`
-- `--color-secondary` `#007bff`
+- `--color-secondary` `#6c757d` (neutral)
 - `--color-danger` `#dc3545`
 - `--color-surface` `#ffffff`
 - `--color-background` `#f2f2f2`
 - `--color-text` `#333333`
+
+Green (`--color-primary`) serves as the sole accent color. The secondary token is a neutral gray used for subdued UI elements.
 
 ### Spacing Scale
 `0.25rem`, `0.5rem`, `0.75rem`, `1rem`, `1.5rem`, `2rem`
@@ -26,7 +28,7 @@ Durations of `150ms`, `250ms`, `400ms` with easing `cubic-bezier(0.4, 0, 0.2, 1)
 ## Component Library
 
 Reusable components live in [`src/components/ui/`](src/components/ui/):
-- **Button** – supports `primary`, `secondary`, and `danger` variants, focus outlines, and hover states.
+- **Button** – supports `primary` and `danger` variants; `secondary` maps to a neutral style.
 - **Card** – surface container with shadow and radius.
 - **Modal** – accessible dialog with overlay, close button, and fade-in animation.
 - **TextInput** – form field with label and focus style.

--- a/frontend/src/css/Navbar.css
+++ b/frontend/src/css/Navbar.css
@@ -70,9 +70,10 @@
   align-items: center;
 }
 
+
 .navbar-links a:hover,
 .navbar-links a.active {
-  color: var(--color-secondary);
+  color: var(--color-primary);
 }
 
 .navbar-links a.active::after {
@@ -82,7 +83,7 @@
   bottom: -4px;
   width: 100%;
   height: 2px;
-  background-color: var(--color-secondary);
+  background-color: var(--color-primary);
   border-radius: 4px;
 }
 

--- a/frontend/src/design/tokens.css
+++ b/frontend/src/design/tokens.css
@@ -2,8 +2,9 @@
   /* Colors */
   --color-primary: #28a745;
   --color-primary-dark: #218838;
-  --color-secondary: #007bff;
-  --color-secondary-dark: #0056b3;
+  /* Deprecated: secondary is now neutral to avoid competing accents */
+  --color-secondary: #6c757d;
+  --color-secondary-dark: #5a6268;
   --color-danger: #d9534f;
   --color-danger-dark: #c9302c;
   --color-danger-darker: #c62828;


### PR DESCRIPTION
## Summary
- remap secondary token to neutral gray so green is sole accent
- switch navbar hover/active styles to use primary green
- document green as only accent in design system

## Testing
- `node server.js` *(fails: Error de conexión a MongoDB: ENOTFOUND)*
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3e4e733c832daa4131f86cf78771