### PR TITLE
Normalize navbar spacing and baseline logo

### DIFF
--- a/frontend/src/css/Navbar.css
+++ b/frontend/src/css/Navbar.css
@@ -28,8 +28,9 @@
 
 .navbar-brand {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--space-2);
+  padding: var(--space-2);
   text-decoration: none;
   color: var(--color-surface);
   font-weight: bold;
@@ -39,6 +40,7 @@
 .logo {
   height: 32px;
   width: auto;
+  display: block;
 }
 
 
@@ -77,7 +79,7 @@
   color: var(--color-surface);
   text-decoration: none;
   font-size: var(--font-size-md);
-  padding: var(--space-2) var(--space-1);
+  padding: var(--space-2);
   position: relative;
   transition: color var(--motion-fast) var(--motion-ease);
   display: flex;


### PR DESCRIPTION
## Summary
- ensure navbar container stays 64px tall and centered
- normalize link spacing and brand padding to 8pt increments
- align logo with text baseline for consistent branding

## Testing
- `cd backend && yarn install`
- `node server.js` *(fails: querySrv ENOTFOUND)*
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689e4510d08c832d85bf9ca38483423f