### PR TITLE
Add Stripe checkout flow to frontend

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,2 @@
+REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
+REACT_APP_API_BASE_URL=http://localhost:5000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,10 +5,12 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@react-google-maps/api": "^2.20.6",
+    "@stripe/stripe-js": "^3.4.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^13.2.1",
+    "axios": "^1.7.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.2.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,8 @@ import CartPage from "./pages/CartPage";
 import CheckoutForm from "./pages/CheckoutForm"; // si existe
 import ProductDetails from "./pages/ProductDetails"; // si existe
 import ConfirmationPage from "./pages/ConfirmationPage";
+import Success from "./pages/Success";
+import Cancel from "./pages/Cancel";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Layout from "./components/Layout";
 import PageTransition from "./components/PageTransition";
@@ -57,6 +59,8 @@ function App() {
               }
             />
             <Route path="/confirmation" element={<ConfirmationPage />} />
+            <Route path="/success" element={<Success />} />
+            <Route path="/cancel" element={<Cancel />} />
             {/* Agregar otras rutas protegidas según sea necesario */}
           </Routes>
         </PageTransition>

--- a/frontend/src/components/CheckoutButton.jsx
+++ b/frontend/src/components/CheckoutButton.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import axios from "axios";
+import { stripePromise } from "../lib/stripe";
+
+const API_BASE = process.env.REACT_APP_API_BASE_URL || "http://localhost:5000";
+
+export default function CheckoutButton({ label = "Buy Now" }) {
+  const onClick = async () => {
+    const stripe = await stripePromise;
+    try {
+      const { data } = await axios.post(`${API_BASE}/api/checkout/session`, {});
+      const { error } = await stripe.redirectToCheckout({ sessionId: data.id });
+      if (error) alert(error.message);
+    } catch (err) {
+      console.error("Checkout init failed:", err);
+      alert("Unable to start checkout. Please try again.");
+    }
+  };
+
+  return <button onClick={onClick}>{label}</button>;
+}

--- a/frontend/src/lib/stripe.js
+++ b/frontend/src/lib/stripe.js
@@ -1,0 +1,6 @@
+import { loadStripe } from "@stripe/stripe-js";
+
+const publishableKey = process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY;
+if (!publishableKey) console.warn("Missing REACT_APP_STRIPE_PUBLISHABLE_KEY");
+
+export const stripePromise = loadStripe(publishableKey);

--- a/frontend/src/pages/Cancel.jsx
+++ b/frontend/src/pages/Cancel.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+export default function Cancel() {
+  const { search } = useLocation();
+  const sessionId = new URLSearchParams(search).get("session_id");
+  return (
+    <div>
+      <h1>Payment canceled</h1>
+      {sessionId && <p>Session ID: {sessionId}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/CheckoutForm.js
+++ b/frontend/src/pages/CheckoutForm.js
@@ -4,6 +4,7 @@ import { CartContext } from "../context/CartContext";
 import { AuthContext } from "../context/AuthContext";
 import "../css/CheckoutForm.css";
 import { Button, Card, Form, TextInput } from "../components/ui";
+import CheckoutButton from "../components/CheckoutButton";
 
 const CheckoutForm = () => {
   const { cartItems, clearCart } = useContext(CartContext);
@@ -350,9 +351,7 @@ const CheckoutForm = () => {
               <Button type="button" onClick={prevStep}>
                 Atrás
               </Button>
-              <Button type="submit" className="submit-button">
-                Confirmar Pedido
-              </Button>
+              <CheckoutButton label="Confirmar Pedido" />
             </div>
           </>
         )}

--- a/frontend/src/pages/Success.jsx
+++ b/frontend/src/pages/Success.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+export default function Success() {
+  const { search } = useLocation();
+  const sessionId = new URLSearchParams(search).get("session_id");
+  return (
+    <div>
+      <h1>Payment successful</h1>
+      {sessionId && <p>Session ID: {sessionId}</p>}
+    </div>
+  );
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1693,6 +1693,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stripe/stripe-js@^3.4.1":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-3.5.0.tgz#7fff3d9d931e972c24dcc8ee25f7481a58879b2b"
+  integrity sha512-pKS3wZnJoL1iTyGBXAvCwduNNeghJHY6QSRSNNvpYnrrQrLZ6Owsazjyynu0e0ObRgks0i7Rv+pe2M7/MBTZpQ==
+
 "@surma/rollup-plugin-off-main-thread@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz#ee34985952ca21558ab0d952f00298ad2190c053"
@@ -2774,6 +2779,15 @@ axe-core@^4.10.0:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
+axios@^1.7.2:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -4692,6 +4706,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
 for-each@^0.3.3:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
@@ -4735,6 +4754,17 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     mime-types "^2.1.35"
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -6543,7 +6573,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.53.0.tgz#3cb63cd820fc29896d9d4e8c32ab4fcd74ccb447"
   integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7719,6 +7749,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.15.0"


### PR DESCRIPTION
## Summary
- integrate Stripe with reusable loader and checkout button
- add success and cancellation pages and corresponding routes
- wire checkout button into existing form

## Testing
- `cd backend && yarn install`
- `cd frontend && yarn install`
- `cd frontend && yarn test --watchAll=false`
- `cd frontend && yarn build`
- `cd backend && node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_689e53101174832da279ea60be455cd0