### PR TITLE
Generate Stripe checkout line items from order

### DIFF
--- a/backend/routes/checkoutRoutes.js
+++ b/backend/routes/checkoutRoutes.js
@@ -5,15 +5,15 @@ const router = express.Router();
 
 router.post("/session", async (req, res) => {
   try {
-    // TODO: validate and price items using your own data
-    const lineItems = [{
+    const { order } = req.body;
+    const lineItems = order.items.map((item) => ({
       price_data: {
-        currency: "usd",
-        product_data: { name: "Awesome Product" },
-        unit_amount: 2000,
+        currency: "mxn",
+        product_data: { name: item.name },
+        unit_amount: item.price * 100,
       },
-      quantity: 1,
-    }];
+      quantity: item.quantity,
+    }));
 
     const session = await stripe.checkout.sessions.create({
       mode: "payment",


### PR DESCRIPTION
## Summary
- build Stripe checkout line items from order items
- send generated line items to checkout session creation

## Testing
- `cd backend && yarn install`
- `yarn node server.js` *(fails: ENOTFOUND _mongodb._tcp.cluster0.i92wc.mongodb.net)*
- `cd frontend && yarn install`
- `yarn test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689e5f2cd36c832db94042171019f265