### PR TITLE
Include cart items in checkout session payload

### DIFF
--- a/frontend/src/components/CheckoutButton.jsx
+++ b/frontend/src/components/CheckoutButton.jsx
@@ -1,14 +1,29 @@
-import React from "react";
+import React, { useContext } from "react";
 import axios from "axios";
 import { stripePromise } from "../lib/stripe";
+import { CartContext } from "../context/CartContext";
 
 const API_BASE = process.env.REACT_APP_API_BASE_URL || "http://localhost:5000";
 
 export default function CheckoutButton({ label = "Buy Now" }) {
+  const { cartItems } = useContext(CartContext);
+
   const onClick = async () => {
     const stripe = await stripePromise;
     try {
-      const { data } = await axios.post(`${API_BASE}/api/checkout/session`, {});
+      const payload = {
+        order: {
+          items: cartItems.map(({ product, quantity }) => ({
+            name: product.name,
+            price: product.price,
+            quantity,
+          })),
+        },
+      };
+      const { data } = await axios.post(
+        `${API_BASE}/api/checkout/session`,
+        payload
+      );
       const { error } = await stripe.redirectToCheckout({ sessionId: data.id });
       if (error) alert(error.message);
     } catch (err) {


### PR DESCRIPTION
## Summary
- load cart items from context in `CheckoutButton`
- send cart products to backend checkout session

## Testing
- `cd backend && yarn install`
- `yarn node server.js` *(fails: Error de conexión a MongoDB)*
- `cd frontend && yarn install`
- `yarn test --watchAll=false`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689e6552b49c832da9d2c563752527bf